### PR TITLE
Add Outlook and IMAP/SMTP mailboxes

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -2,3 +2,10 @@
 # Leave empty at deploy time if you like — you can add both later under Workers → Settings → Variables and Secrets.
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+
+# Microsoft Entra app registration for connecting Outlook.com / Microsoft 365 mailboxes
+# (portal.azure.com → Entra ID → App registrations → Web app, redirect URI …/auth/microsoft/callback).
+# Delegated permissions: Mail.ReadWrite, Mail.Send, User.Read, offline_access.
+# Optional — leave empty if you only connect Gmail or custom-domain mailboxes.
+MS_CLIENT_ID=
+MS_CLIENT_SECRET=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Typecheck
+        run: npm run check
+      - name: Test
+        run: npm test
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - name: Typecheck

--- a/API.md
+++ b/API.md
@@ -9,9 +9,11 @@ Account-scoped routes take the account via `X-Account-Id` header (web stores the
 - `POST /auth/logout`
 - `GET  /auth/google/start` -> 302 to Google consent (scopes: gmail.modify, userinfo.email, userinfo.profile). Requires session.
 - `GET  /auth/google/callback?code&state` -> creates/updates account, 302 to `/` (or `/?connected=1`).
+- `GET  /auth/microsoft/start` -> 302 to Microsoft consent (scopes: Mail.ReadWrite, Mail.Send, User.Read, offline_access, openid/email/profile). Requires session.
+- `GET  /auth/microsoft/callback?code&state` -> creates/updates an account with `provider = 'outlook'`, 302 to `/?connected=1`.
 
 ## Me / settings
-- `GET  /api/me` -> {user, accounts: Account[], registration_open}
+- `GET  /api/me` -> {user, accounts: Account[], registration_open, google_configured, microsoft_configured}
 - `PATCH /api/me` {name?, settings?} -> {user}
 - `POST /api/me/password` {current,next}
 - `GET  /api/accounts` -> Account[]
@@ -131,7 +133,7 @@ Without `CF_API_TOKEN`, domain setup is "manual": the API returns the exact step
   `catch_all` makes this mailbox receive mail for any unknown address on the domain.
 - `PATCH /api/domains/:id` { catch_all_account_id?: string|null }
 - Mailboxes are deleted via `DELETE /api/accounts/:id` (existing).
-- `Account` gains `provider: 'gmail'|'domain'` and `domain_id: string|null`.
+- `Account` gains `provider: 'gmail'|'domain'|'outlook'` and `domain_id: string|null`.
 - Inbound (`email()` handler): parse with postal-mime; look up RCPT TO in accounts (provider domain); else domain catch-all;
   else `setReject("550 5.1.1 No such mailbox")`. Ingest as a message (same screener/bucket logic; attachments stored in a new
   `attachment_blobs` table when total ≤ 900KB per attachment, else metadata only with `stored=0`), dedupe on Message-ID.

--- a/API.md
+++ b/API.md
@@ -22,7 +22,9 @@ Account-scoped routes take the account via `X-Account-Id` header (web stores the
 - `POST /api/accounts/:id/sync` -> triggers a sync now -> {ok, added}
 - `POST /api/accounts/imap` {email, display_name?, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username?, password, folder?} -> {ok, account}.
   Verifies both servers before writing; 400 `connection_failed` with the protocol error, 409 `account_exists`, 400 `smtp_port_25_blocked`.
-- `GET  /api/accounts/:id/imap` -> stored settings, password reduced to `password_hint`.
+- `GET  /api/accounts/:id/imap` -> stored settings; the password is never returned, only a fixed placeholder.
+- `PATCH /api/accounts/:id/imap` {imap_host?, imap_port?, imap_security?, smtp_host?, smtp_port?, smtp_security?, username?, password?, folder?} -> {ok, account}.
+  Verifies both servers before writing; omitting `password` keeps the stored one. Changing `folder` re-baselines the UID cursor.
 - `POST /api/accounts/:id/imap/test` -> {ok} or 400 {ok:false, error}.
 
 ## Mail (account-scoped)

--- a/API.md
+++ b/API.md
@@ -20,6 +20,10 @@ Account-scoped routes take the account via `X-Account-Id` header (web stores the
 - `PATCH /api/accounts/:id` {signature?, cover_art?, display_name?} -> Account
 - `DELETE /api/accounts/:id` (disconnect + delete data)
 - `POST /api/accounts/:id/sync` -> triggers a sync now -> {ok, added}
+- `POST /api/accounts/imap` {email, display_name?, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security, username?, password, folder?} -> {ok, account}.
+  Verifies both servers before writing; 400 `connection_failed` with the protocol error, 409 `account_exists`, 400 `smtp_port_25_blocked`.
+- `GET  /api/accounts/:id/imap` -> stored settings, password reduced to `password_hint`.
+- `POST /api/accounts/:id/imap/test` -> {ok} or 400 {ok:false, error}.
 
 ## Mail (account-scoped)
 - `GET /api/counts` -> Counts
@@ -133,7 +137,7 @@ Without `CF_API_TOKEN`, domain setup is "manual": the API returns the exact step
   `catch_all` makes this mailbox receive mail for any unknown address on the domain.
 - `PATCH /api/domains/:id` { catch_all_account_id?: string|null }
 - Mailboxes are deleted via `DELETE /api/accounts/:id` (existing).
-- `Account` gains `provider: 'gmail'|'domain'|'outlook'` and `domain_id: string|null`.
+- `Account` gains `provider: 'gmail'|'domain'|'outlook'|'imap'` and `domain_id: string|null`.
 - Inbound (`email()` handler): parse with postal-mime; look up RCPT TO in accounts (provider domain); else domain catch-all;
   else `setReject("550 5.1.1 No such mailbox")`. Ingest as a message (same screener/bucket logic; attachments stored in a new
   `attachment_blobs` table when total ≤ 900KB per attachment, else metadata only with `stored=0`), dedupe on Message-ID.

--- a/README.md
+++ b/README.md
@@ -230,19 +230,20 @@ npm run dev                       # vite on :5173 (proxies /api and /auth)
 ```
 Inbound mail can be simulated against the local worker: `POST http://localhost:8787/cdn-cgi/handler/email?from=a@b.co&to=you@yourdomain` with a raw RFC 822 body.
 
-## Other mailboxes (Zoho, Fastmail, webmail…)
+## Other mailboxes (Fastmail, Migadu, webmail…)
 
 Settings → Accounts → **Add mailbox**. Any server that speaks IMAP and SMTP works: pick a provider
-preset or type the host names yourself, then give it an app-specific password. heyflare checks both
-servers before saving, so a typo never leaves a half-connected account behind.
+preset or type the host names yourself, then give it an app-specific password. heyflare logs in to
+both servers before saving, so a typo never leaves a half-connected account behind. Passwords are
+encrypted at rest and never returned by the API.
 
-- **IMAP** on 993 with implicit TLS.
-- **SMTP** on 465 (implicit TLS) or 587 (STARTTLS). **Port 25 cannot work** — Cloudflare blocks
-  outbound connections to it, with no way around it.
-- Passwords are encrypted at rest with AES-GCM, keyed off `SESSION_SECRET`, and are never returned
-  by the API — Settings shows only a masked hint.
-- Turn IMAP access on with your provider first (Zoho in particular requires it), and use an
-  app-specific password if you have two-factor auth enabled.
+**Port 25 cannot work** — Cloudflare blocks outbound connections to it. Use 465 or 587.
+
+Note that **Zoho's free plan cannot be connected at all**: it excludes IMAP, POP3 and forwarding, and
+is browser-only. A paid plan is required.
+
+[`docs/MAILBOXES.md`](docs/MAILBOXES.md) covers all four mailbox types, the setup each one needs, and
+what to do when a connection is refused.
 
 ## Tests
 
@@ -259,6 +260,7 @@ TOTP (Google Authenticator, 1Password, Authy…) with 10 single-use recovery cod
 
 ## Docs
 - `API.md` — the worker/web API contract.
+- [`docs/MAILBOXES.md`](docs/MAILBOXES.md) — connecting Gmail, Outlook, IMAP/SMTP and domain mailboxes, with troubleshooting.
 - `DESIGN.md` — the design system (Notion-minimal, shadcn, mobile spec).
 - [`docs/CALENDAR.md`](docs/CALENDAR.md) — how the calendar is put together: sources, views, schema, API, sync.
 - [`docs/UPDATING.md`](docs/UPDATING.md) — what an update changes, how to update, how to roll back.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ lives in a resizable side panel and can see the thread you're reading.
 - **Gmail** via OAuth (incremental history sync every minute plus sync-on-focus; sending through Gmail).
 - **Outlook** via Microsoft OAuth — Outlook.com, Hotmail, Live and Microsoft 365 work accounts, over Microsoft Graph
   (delta sync every minute plus sync-on-focus; sending through Graph, so it lands in Outlook's Sent Items too).
+- **Any IMAP/SMTP mailbox** — Zoho, Fastmail, Migadu, cPanel webmail or your own server, with an app password.
+  Polled every minute over IMAP; sending goes through the provider's own SMTP, so they sign DKIM for you.
 - **Custom domain mailboxes** — inbound through Cloudflare Email Routing, outbound through Cloudflare Email Sending or Resend.
 - Contacts with Google profile photos, BIMI brand logos, address-book autocomplete, clips, collections, labels, files,
   notes, merge and rename threads, spy-pixel blocking, keyboard shortcuts, command palette, dark mode, two-factor auth.
@@ -192,6 +194,7 @@ new database migrations apply themselves on the first request after a deploy. Fu
 ## How mail flows
 - Connecting Gmail imports **nothing**. It records Gmail's history cursor and only mail that arrives afterwards syncs.
 - Connecting Outlook imports **nothing** either — it records a Graph delta cursor and watches from there.
+- Adding an IMAP mailbox imports **nothing** either — it records the folder's UIDVALIDITY and highest UID, and watches from there.
 - Every first-time sender waits in the **Screener**. Decisions are per person and apply across all your accounts.
 - Gmail and Outlook are polled every minute (Cloudflare cron) and whenever the app is opened or regains focus (throttled). Custom-domain
   mail is pushed in instantly by Email Routing.
@@ -226,6 +229,20 @@ npm run dev:worker                # worker on :8787 (API, cron, email handler)
 npm run dev                       # vite on :5173 (proxies /api and /auth)
 ```
 Inbound mail can be simulated against the local worker: `POST http://localhost:8787/cdn-cgi/handler/email?from=a@b.co&to=you@yourdomain` with a raw RFC 822 body.
+
+## Other mailboxes (Zoho, Fastmail, webmail…)
+
+Settings → Accounts → **Add mailbox**. Any server that speaks IMAP and SMTP works: pick a provider
+preset or type the host names yourself, then give it an app-specific password. heyflare checks both
+servers before saving, so a typo never leaves a half-connected account behind.
+
+- **IMAP** on 993 with implicit TLS.
+- **SMTP** on 465 (implicit TLS) or 587 (STARTTLS). **Port 25 cannot work** — Cloudflare blocks
+  outbound connections to it, with no way around it.
+- Passwords are encrypted at rest with AES-GCM, keyed off `SESSION_SECRET`, and are never returned
+  by the API — Settings shows only a masked hint.
+- Turn IMAP access on with your provider first (Zoho in particular requires it), and use an
+  app-specific password if you have two-factor auth enabled.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ lives in a resizable side panel and can see the thread you're reading.
   next three days shown at the top of the Imbox. `0` flips between mail and calendar.
 - **Unified inbox** across every connected account, with per-account glyphs and a From picker in compose.
 - **Gmail** via OAuth (incremental history sync every minute plus sync-on-focus; sending through Gmail).
+- **Outlook** via Microsoft OAuth — Outlook.com, Hotmail, Live and Microsoft 365 work accounts, over Microsoft Graph
+  (delta sync every minute plus sync-on-focus; sending through Graph, so it lands in Outlook's Sent Items too).
 - **Custom domain mailboxes** — inbound through Cloudflare Email Routing, outbound through Cloudflare Email Sending or Resend.
 - Contacts with Google profile photos, BIMI brand logos, address-book autocomplete, clips, collections, labels, files,
   notes, merge and rename threads, spy-pixel blocking, keyboard shortcuts, command palette, dark mode, two-factor auth.
@@ -104,6 +106,28 @@ Prerequisites: a Cloudflare account, Node 20+, and a Google Cloud project.
 4. **Credentials → OAuth client ID → Web application**:
    - Authorized JavaScript origins: `https://YOUR_HOST`
    - Authorized redirect URIs: `https://YOUR_HOST/auth/google/callback` and `http://localhost:8787/auth/google/callback`
+
+### 1b. Microsoft app registration (optional — only to connect Outlook)
+
+Microsoft has retired Basic authentication for IMAP/POP/SMTP, so an Outlook mailbox can only be
+connected over OAuth. heyflare talks to Microsoft Graph rather than IMAP: plain HTTPS, and a delta
+cursor that works the same way Gmail's history id does.
+
+1. https://portal.azure.com → **Microsoft Entra ID → App registrations → New registration**.
+2. **Supported account types**: *Accounts in any organizational directory and personal Microsoft accounts*
+   — this is what lets both `@outlook.com` addresses and Microsoft 365 work accounts sign in.
+3. **Redirect URI** (platform: Web): `https://YOUR_HOST/auth/microsoft/callback`, and
+   `http://localhost:8787/auth/microsoft/callback` for local development.
+4. **Certificates & secrets → New client secret**; copy the value.
+5. **API permissions → Microsoft Graph → Delegated**: `Mail.ReadWrite`, `Mail.Send`, `User.Read`, `offline_access`.
+6. Set the two secrets:
+   ```sh
+   npx wrangler secret put MS_CLIENT_ID     -c wrangler.local.jsonc
+   npx wrangler secret put MS_CLIENT_SECRET -c wrangler.local.jsonc
+   ```
+
+Then **Connect Outlook** from the sidebar. As with Gmail, connecting imports nothing: it records where
+your inbox is now and syncs only what arrives afterwards.
 
 ### 2. Cloudflare
 ```sh
@@ -167,8 +191,9 @@ new database migrations apply themselves on the first request after a deploy. Fu
 
 ## How mail flows
 - Connecting Gmail imports **nothing**. It records Gmail's history cursor and only mail that arrives afterwards syncs.
+- Connecting Outlook imports **nothing** either — it records a Graph delta cursor and watches from there.
 - Every first-time sender waits in the **Screener**. Decisions are per person and apply across all your accounts.
-- Gmail is polled every minute (Cloudflare cron) and whenever the app is opened or regains focus (throttled). Custom-domain
+- Gmail and Outlook are polled every minute (Cloudflare cron) and whenever the app is opened or regains focus (throttled). Custom-domain
   mail is pushed in instantly by Email Routing.
 - Sending uses your Gmail account (it appears in Gmail's Sent too), with undo-send and send-later.
 - Contact photos come from the People API (profile + directory) and BIMI logos from DNS; otherwise initials.
@@ -201,6 +226,16 @@ npm run dev:worker                # worker on :8787 (API, cron, email handler)
 npm run dev                       # vite on :5173 (proxies /api and /auth)
 ```
 Inbound mail can be simulated against the local worker: `POST http://localhost:8787/cdn-cgi/handler/email?from=a@b.co&to=you@yourdomain` with a raw RFC 822 body.
+
+## Tests
+
+```sh
+npm test          # vitest, inside workerd with a real D1 (migrations, ingest, send routing)
+npm run check     # typecheck web, worker and tests
+```
+
+`scripts/ai-openai-mock.test.ts` is a separate standalone script (it spins a real Node HTTP server)
+and is not part of `npm test`.
 
 ## Two-factor authentication
 TOTP (Google Authenticator, 1Password, Authy…) with 10 single-use recovery codes. Settings → Security.

--- a/docs/MAILBOXES.md
+++ b/docs/MAILBOXES.md
@@ -1,0 +1,153 @@
+# Connecting mailboxes
+
+heyflare can read and send from four kinds of mailbox. They all land in the same unified Imbox,
+share one Screener, and behave identically once connected — the difference is only in how mail gets
+in and out.
+
+| Type | Good for | Inbound | Outbound | Needs |
+|---|---|---|---|---|
+| **Gmail** | Gmail, Google Workspace | Gmail API, polled every minute | Gmail API | Google OAuth client |
+| **Outlook** | Outlook.com, Hotmail, Live, Microsoft 365 | Microsoft Graph, polled every minute | Graph `sendMail` | Microsoft Entra app |
+| **IMAP/SMTP** | Fastmail, Migadu, cPanel webmail, self-hosted | IMAP, polled every minute | The provider's SMTP | An app password |
+| **Domain mailbox** | An address on a domain you own | Cloudflare Email Routing — **pushed instantly** | Cloudflare Email Sending or Resend | The domain on Cloudflare |
+
+Whichever you pick, **connecting imports nothing**. heyflare records where the mailbox stands right
+now and syncs only what arrives afterwards. That is deliberate: it keeps the Screener meaningful
+instead of burying you in years of history.
+
+Every first-time sender waits in the **Screener** for a yes or no — so after connecting, new mail
+appears there rather than in the Imbox until you have decided about the sender.
+
+---
+
+## Gmail
+
+1. Create an OAuth client (see the main README, "Google OAuth client").
+2. Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.
+3. Sidebar → **Connect Gmail**.
+
+---
+
+## Outlook
+
+Microsoft retired Basic authentication for IMAP, POP and SMTP on **16 September 2024**, and removed
+app passwords with it. A username and password will not connect an Outlook mailbox to anything,
+in heyflare or any other client — OAuth is the only route. heyflare therefore talks to Microsoft
+Graph over HTTPS rather than IMAP.
+
+### Register the app
+
+If you sign in to the Azure portal with a **personal** Microsoft account you land in a shared
+"Microsoft Services" tenant that has no directory, so app registration is blocked. Symptoms are
+`AADSTS16000` on sign-in, or `401 No access` on the App registrations blade. You need a directory of
+your own first: create one via **Microsoft Entra ID → Manage tenants → Create**, or by signing up at
+<https://azure.microsoft.com/free>, then switch into it with the directory picker.
+
+1. **Entra ID → App registrations → New registration**.
+2. **Supported account types**: *Accounts in any organizational directory and personal Microsoft
+   accounts*. This is what lets both `@outlook.com` and work accounts sign in.
+3. **Redirect URI** (platform **Web**): `https://YOUR_HOST/auth/microsoft/callback`.
+   Add `http://localhost:8787/auth/microsoft/callback` too for local development — Microsoft permits
+   plain `http` for `localhost` specifically.
+4. **Certificates & secrets → New client secret**. Copy the **Value** column, not "Secret ID"; it is
+   shown only once.
+5. **API permissions → Microsoft Graph → Delegated permissions**, add all four:
+   `Mail.ReadWrite`, `Mail.Send`, `User.Read`, `offline_access`.
+   `offline_access` is what yields a refresh token — without it, syncing stops after about an hour.
+   No admin consent is required; you consent yourself at sign-in.
+
+### Connect
+
+Set `MS_CLIENT_ID` and `MS_CLIENT_SECRET`, then sidebar → **Connect Outlook**.
+
+---
+
+## IMAP / SMTP
+
+Settings → Accounts → **Add mailbox**. Pick a provider preset or enter the servers yourself, then
+supply an **app-specific password** where the provider offers one. heyflare logs in to *both*
+servers before saving anything, so a mistake is reported immediately rather than leaving a
+half-connected account behind.
+
+- **IMAP**: port 993, implicit TLS.
+- **SMTP**: port 465 (implicit TLS) or 587 (STARTTLS).
+- **Port 25 cannot work.** Cloudflare blocks outbound connections to it and there is no way around
+  that. Use 465 or 587.
+
+Your password is encrypted at rest with AES-GCM keyed off `SESSION_SECRET`, is never returned by the
+API, and Settings shows only a masked hint.
+
+### Before you start
+
+Most providers need IMAP switched on explicitly, and most require an app-specific password rather
+than your account password once two-factor auth is enabled.
+
+| Provider | IMAP host | SMTP host | Notes |
+|---|---|---|---|
+| Fastmail | `imap.fastmail.com` | `smtp.fastmail.com` | App password under Settings → Privacy & Security |
+| Migadu | `imap.migadu.com` | `smtp.migadu.com` | |
+| Zoho (personal) | `imap.zoho.com` | `smtp.zoho.com` | For `@zohomail.com` addresses |
+| Zoho (own domain) | `imappro.zoho.com` | `smtppro.zoho.com` | Organisation accounts use the `pro` hosts |
+| cPanel webmail | usually `mail.yourdomain.com` | usually `mail.yourdomain.com` | Check your host's control panel |
+
+> **Zoho's free plan cannot be connected at all.** It excludes IMAP, POP3, ActiveSync *and*
+> forwarding — it is browser-only, and no mail client can reach it. Zoho's own documentation states
+> "For newly signed up users (Free plan), the IMAP Access feature will not be available." A paid plan
+> (Mail Lite or above) is required. On a non-US data centre, swap the host suffix for `.eu`, `.in`
+> or `.com.au`.
+
+Because mail is sent through your provider's own SMTP server, **they** sign DKIM for you —
+deliverability is theirs, not something heyflare has to solve.
+
+---
+
+## Domain mailboxes
+
+An address on a domain you own, with the domain set up as a zone on your Cloudflare account. This is
+the only type where mail is **pushed** the moment it arrives rather than polled, and it needs no
+third-party account at all.
+
+Settings → **Domains** → add the domain → create a mailbox. See the main README for DNS and
+`CF_API_TOKEN` details.
+
+Two things to know:
+
+- **Enabling Email Routing takes over all mail for that domain.** The MX records change to
+  Cloudflare, so any existing provider stops receiving. heyflare shows the current MX and asks first.
+- **Inbound needs a deployed Worker.** Cloudflare Email Routing delivers to your Worker on the
+  internet and cannot reach `localhost`. To exercise the path locally, post a raw message to the
+  local email handler instead:
+
+  ```sh
+  curl -X POST "http://localhost:8787/cdn-cgi/handler/email?from=a@b.co&to=you@yourdomain" \
+       --data-binary @message.eml
+  ```
+
+Sending needs Cloudflare Email Sending (Workers Paid) or a `RESEND_API_KEY`. Until one is set, a
+domain mailbox receives but cannot send.
+
+---
+
+## Troubleshooting
+
+**Nothing appears after connecting.** Expected at first — nothing historical is imported. Send
+yourself a new message, then look in the **Screener**, not the Imbox: first-time senders wait there.
+
+**Nothing syncs when running locally.** `wrangler dev` does not fire the cron trigger, so nothing
+polls on its own. Use **Sync** in Settings → Accounts, or switch away from the browser tab and back
+(sync-on-focus, throttled to 45 seconds). Deployed, the cron handles it every minute.
+
+**`AADSTS50011` redirect mismatch.** The redirect URI in Azure must match exactly, including scheme,
+port and any trailing slash.
+
+**`AADSTS65001` consent required.** The Graph permissions were not added or not saved.
+
+**Outlook stops syncing after about an hour.** `offline_access` is missing from the app
+registration, so no refresh token was issued.
+
+**IMAP or SMTP reports "Invalid credentials" / `535`.** In order of likelihood: the provider's plan
+does not include IMAP; IMAP access is not enabled in their settings; you used your account password
+where an app-specific password is required; or an organisation account is pointed at the personal
+host names.
+
+**`smtp_port_25_blocked`.** Cloudflare blocks outbound port 25. Use 465 or 587.

--- a/docs/MAILBOXES.md
+++ b/docs/MAILBOXES.md
@@ -166,6 +166,17 @@ your mailbox, so rotating one does not sign anybody out.
 
 Credentials are never written to the repository. `.dev.vars` is git-ignored.
 
+### You do not need any of this to install
+
+The setup wizard asks whether to add a Google OAuth client and defaults to **no**; the one-click
+deploy accepts empty values; and `/setup` only needs an email and a password. A fresh install runs
+perfectly well with no OAuth configured at all — you simply will not see **Connect Gmail** or
+**Connect Outlook** until the matching credentials exist, and Settings tells you which are missing.
+**Add mailbox** (IMAP/SMTP) works from the start, since it needs no OAuth app.
+
+Add the credentials whenever you are ready, from Settings or with `wrangler secret put`. Nothing has
+to be decided at install time.
+
 ---
 
 ## Troubleshooting

--- a/docs/MAILBOXES.md
+++ b/docs/MAILBOXES.md
@@ -106,6 +106,16 @@ than your account password once two-factor auth is enabled.
 Because mail is sent through your provider's own SMTP server, **they** sign DKIM for you —
 deliverability is theirs, not something heyflare has to solve.
 
+### Changing the password or the servers
+
+Settings → Accounts → **Server settings** on the mailbox. Both servers are checked before anything
+is saved, and your synced mail is kept — you never have to delete and re-add a mailbox to rotate an
+app password. Leave the password blank to change only a host or port.
+
+If the credentials stop working, the mailbox is marked **disconnected** rather than being retried
+every minute, so a wrong password costs one failure rather than a write per minute forever. Saving
+working credentials brings it straight back.
+
 ---
 
 ## Domain mailboxes

--- a/docs/MAILBOXES.md
+++ b/docs/MAILBOXES.md
@@ -49,8 +49,15 @@ your own first: create one via **Microsoft Entra ID → Manage tenants → Creat
 3. **Redirect URI** (platform **Web**): `https://YOUR_HOST/auth/microsoft/callback`.
    Add `http://localhost:8787/auth/microsoft/callback` too for local development — Microsoft permits
    plain `http` for `localhost` specifically.
-4. **Certificates & secrets → New client secret**. Copy the **Value** column, not "Secret ID"; it is
-   shown only once.
+4. **Certificates & secrets → New client secret**, then copy the **Value** column.
+
+   Two columns in that table look like credentials and only one is. **Value** is the secret that
+   authenticates. **Secret ID** is a GUID naming the row — Azure's internal reference to that
+   credential, useless for signing in and harmless to share.
+
+   The Value is displayed **once**, right after you create it, and is masked permanently after you
+   navigate away; Microsoft stores only a hash, so there is no way to reveal it later. If you did not
+   copy it, you cannot recover it — create a new secret and delete the old one.
 5. **API permissions → Microsoft Graph → Delegated permissions**, add all four:
    `Mail.ReadWrite`, `Mail.Send`, `User.Read`, `offline_access`.
    `offline_access` is what yields a refresh token — without it, syncing stops after about an hour.

--- a/docs/MAILBOXES.md
+++ b/docs/MAILBOXES.md
@@ -128,6 +128,39 @@ domain mailbox receives but cannot send.
 
 ---
 
+## Where OAuth credentials live, and rotating them
+
+Gmail and Outlook each need an OAuth app's client ID and secret. heyflare reads them from two
+places, in this order:
+
+1. **Worker secrets** — `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`, `MS_CLIENT_ID` /
+   `MS_CLIENT_SECRET`. Set with `wrangler secret put`, or `.dev.vars` locally. These always win.
+2. **Settings → Accounts → Provider credentials** — stored in the database, encrypted with AES-GCM
+   keyed off `SESSION_SECRET`, and never returned by the API.
+
+A Worker secret is the stronger place to keep one, because it lives in Cloudflare's secret store
+rather than your database. The stored fallback exists so a secret can be rotated from the browser
+without CLI access and a redeploy — which matters because **Microsoft client secrets expire**, 24
+months at the most and often sooner. When a Worker secret is set, the form shows the provider as
+managed and refuses to store a value that would be ignored.
+
+Rotating:
+
+```sh
+# Worker secret
+npx wrangler secret put MS_CLIENT_SECRET
+
+# or, if no Worker secret is set: Settings → Accounts → Provider credentials → paste → Save
+```
+
+Either way, create the new secret in the provider's console first, switch heyflare over, then delete
+the old one. Existing connected mailboxes keep working — the credentials authenticate the *app*, not
+your mailbox, so rotating one does not sign anybody out.
+
+Credentials are never written to the repository. `.dev.vars` is git-ignored.
+
+---
+
 ## Troubleshooting
 
 **Nothing appears after connecting.** Expected at first — nothing historical is imported. Send

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -8,9 +8,11 @@ and how to go back if something looks wrong.
 **Replaced:** the Worker code (API, sync, AI, inbound mail) and the static assets of the web app.
 
 **Never touched:** your D1 database — mail, threads, contacts, screener decisions, labels, collections,
-clips, notes, drafts, bundles, settings, two-factor secrets, AI provider keys and AI memory. Your Worker
-secrets (Google OAuth, `CF_API_TOKEN`, `RESEND_API_KEY`, the session secret) live in Cloudflare and
-survive deploys too, so nobody gets logged out and no account needs reconnecting.
+clips, notes, drafts, bundles, settings, two-factor secrets, AI provider keys and AI memory, plus the
+encrypted IMAP mailbox passwords and any OAuth client credentials stored from Settings. Your Worker
+secrets (Google and Microsoft OAuth, `CF_API_TOKEN`, `RESEND_API_KEY`, the session secret) live in
+Cloudflare and survive deploys too, so nobody gets logged out and no account needs reconnecting —
+Gmail, Outlook and IMAP mailboxes all keep syncing across an update.
 
 Database changes ship as migrations that run themselves on the first request after a deploy — there is no
 manual `db:migrate` step. Migrations only add tables and columns, so existing rows are kept as they are.
@@ -55,6 +57,11 @@ and drag it over the old app.
 
 The Mac app and the server update independently: the app is only a native window around your server, so
 either can be newer than the other.
+
+That also means **new mailbox types need no app update**. The apps carry no provider-specific code —
+they load the web app from your server — so Outlook and IMAP mailboxes appear in the Mac and iPhone
+apps as soon as the server is deployed. Rebuild the app only for changes to the native shell itself:
+the title bar, menus, notifications, dock badge or auto-updates.
 
 ## Which version am I running?
 

--- a/migrations/0016_outlook.sql
+++ b/migrations/0016_outlook.sql
@@ -1,0 +1,3 @@
+-- Outlook mailboxes (accounts.provider = 'outlook'), synced over Microsoft Graph.
+-- delta_link stores the whole @odata.deltaLink URL: Graph's equivalent of Gmail's history_id cursor.
+ALTER TABLE accounts ADD COLUMN delta_link TEXT;

--- a/migrations/0017_imap.sql
+++ b/migrations/0017_imap.sql
@@ -1,0 +1,19 @@
+-- Third-party IMAP/SMTP mailboxes (accounts.provider = 'imap'): Zoho, Fastmail, Migadu, cPanel webmail.
+-- Credentials live here rather than on `accounts` so `SELECT * FROM accounts` never drags the
+-- ciphertext around. password_enc is AES-GCM via ai/crypto.ts, keyed off SESSION_SECRET.
+CREATE TABLE IF NOT EXISTS imap_accounts (
+  account_id TEXT PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
+  imap_host TEXT NOT NULL,
+  imap_port INTEGER NOT NULL DEFAULT 993,
+  imap_security TEXT NOT NULL DEFAULT 'tls',
+  smtp_host TEXT NOT NULL,
+  smtp_port INTEGER NOT NULL DEFAULT 465,
+  smtp_security TEXT NOT NULL DEFAULT 'tls',
+  username TEXT NOT NULL,
+  password_enc TEXT NOT NULL DEFAULT '',
+  password_hint TEXT NOT NULL DEFAULT '',
+  folder TEXT NOT NULL DEFAULT 'INBOX',
+  uid_validity INTEGER NOT NULL DEFAULT 0,
+  last_uid INTEGER NOT NULL DEFAULT 0,
+  updated_at INTEGER NOT NULL
+);

--- a/migrations/0018_oauth_credentials.sql
+++ b/migrations/0018_oauth_credentials.sql
@@ -1,0 +1,10 @@
+-- OAuth app credentials for the mail providers, so they can be rotated from Settings without a
+-- redeploy. Microsoft client secrets expire (24 months at most), which makes rotation recurring
+-- maintenance rather than a one-off. A Worker secret, when set, always wins over the stored value.
+CREATE TABLE IF NOT EXISTS oauth_credentials (
+  provider TEXT PRIMARY KEY,
+  client_id TEXT NOT NULL DEFAULT '',
+  secret_enc TEXT NOT NULL DEFAULT '',
+  secret_hint TEXT NOT NULL DEFAULT '',
+  updated_at INTEGER NOT NULL
+);

--- a/migrations/0019_oauth_override.sql
+++ b/migrations/0019_oauth_override.sql
@@ -1,0 +1,4 @@
+-- Lets stored credentials deliberately take precedence over a Worker secret.
+-- Without this, anyone who configured via `wrangler secret put` could never rotate from the UI —
+-- which is the one thing the settings form exists to make possible.
+ALTER TABLE oauth_credentials ADD COLUMN override_env INTEGER NOT NULL DEFAULT 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "heyflare",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "heyflare",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.123.0",
         "@fontsource-variable/geist": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "heyflare",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "heyflare",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.123.0",
         "@fontsource-variable/geist": "^5.3.0",
@@ -35,6 +35,7 @@
         "zod": "^4.5.4"
       },
       "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.10.0",
         "@cloudflare/workers-types": "^5.20260831.1",
         "@tailwindcss/vite": "^4.0.0",
         "@types/dompurify": "^3.0.5",
@@ -46,6 +47,7 @@
         "tailwindcss": "^4.0.0",
         "typescript": "^5.6.2",
         "vite": "^5.4.8",
+        "vitest": "^3.2.4",
         "wrangler": "^4.128.0"
       }
     },
@@ -540,6 +542,1202 @@
         "workerd": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.10.15",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.10.15.tgz",
+      "integrity": "sha512-eISef+JvqC5xr6WBv2+kc6WEjxuKSrZ1MdMuIwdb4vsh8olqw7WHW5pLBL/UzAhbLVlXaAL1uH9UyxIlFkJe7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "birpc": "0.2.14",
+        "cjs-module-lexer": "^1.2.3",
+        "devalue": "^5.3.2",
+        "miniflare": "4.20251210.0",
+        "semver": "^7.7.1",
+        "wrangler": "4.54.0",
+        "zod": "^3.22.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "2.0.x - 3.2.x",
+        "@vitest/snapshot": "2.0.x - 3.2.x",
+        "vitest": "2.0.x - 3.2.x"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.1.tgz",
+      "integrity": "sha512-Nu8ahitGFFJztxUml9oD/DLb7Z28C8cd8F46IVQ7y5Btz575pvMY8AqZsXkX7Gds29eCKdMgIHjIvzskHgPSFg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/unenv-preset": {
+      "version": "2.7.13",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.7.13.tgz",
+      "integrity": "sha512-NulO1H8R/DzsJguLC0ndMuk4Ufv0KSlN+E54ay9rn9ZCQo0kpAPwwh3LhgpZ96a3Dr6L9LqW57M4CqC34iLOvw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "^1.20251202.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20251210.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20251210.0.tgz",
+      "integrity": "sha512-Nn9X1moUDERA9xtFdCQ2XpQXgAS9pOjiCxvOT8sVx9UJLAiBLkfSCGbpsYdarODGybXCpjRlc77Yppuolvt7oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20251210.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20251210.0.tgz",
+      "integrity": "sha512-Mg8iYIZQFnbevq/ls9eW/eneWTk/EE13Pej1MwfkY5et0jVpdHnvOLywy/o+QtMJFef1AjsqXGULwAneYyBfHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20251210.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20251210.0.tgz",
+      "integrity": "sha512-kjC2fCZhZ2Gkm1biwk2qByAYpGguK5Gf5ic8owzSCUw0FOUfQxTZUT9Lp3gApxsfTLbbnLBrX/xzWjywH9QR4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20251210.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20251210.0.tgz",
+      "integrity": "sha512-2IB37nXi7PZVQLa1OCuO7/6pNxqisRSO8DmCQ5x/3sezI5op1vwOxAcb1osAnuVsVN9bbvpw70HJvhKruFJTuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20251210.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20251210.0.tgz",
+      "integrity": "sha512-Uaz6/9XE+D6E7pCY4OvkCuJHu7HcSDzeGcCGY1HLhojXhHd7yL52c3yfiyJdS8hPatiAa0nn5qSI/42+aTdDSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.0",
+        "@esbuild/android-arm": "0.27.0",
+        "@esbuild/android-arm64": "0.27.0",
+        "@esbuild/android-x64": "0.27.0",
+        "@esbuild/darwin-arm64": "0.27.0",
+        "@esbuild/darwin-x64": "0.27.0",
+        "@esbuild/freebsd-arm64": "0.27.0",
+        "@esbuild/freebsd-x64": "0.27.0",
+        "@esbuild/linux-arm": "0.27.0",
+        "@esbuild/linux-arm64": "0.27.0",
+        "@esbuild/linux-ia32": "0.27.0",
+        "@esbuild/linux-loong64": "0.27.0",
+        "@esbuild/linux-mips64el": "0.27.0",
+        "@esbuild/linux-ppc64": "0.27.0",
+        "@esbuild/linux-riscv64": "0.27.0",
+        "@esbuild/linux-s390x": "0.27.0",
+        "@esbuild/linux-x64": "0.27.0",
+        "@esbuild/netbsd-arm64": "0.27.0",
+        "@esbuild/netbsd-x64": "0.27.0",
+        "@esbuild/openbsd-arm64": "0.27.0",
+        "@esbuild/openbsd-x64": "0.27.0",
+        "@esbuild/openharmony-arm64": "0.27.0",
+        "@esbuild/sunos-x64": "0.27.0",
+        "@esbuild/win32-arm64": "0.27.0",
+        "@esbuild/win32-ia32": "0.27.0",
+        "@esbuild/win32-x64": "0.27.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/miniflare": {
+      "version": "4.20251210.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20251210.0.tgz",
+      "integrity": "sha512-k6kIoXwGVqlPZb0hcn+X7BmnK+8BjIIkusQPY22kCo2RaQJ/LzAjtxHQdGXerlHSnJyQivDQsL6BJHMpQfUFyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "sharp": "^0.33.5",
+        "stoppable": "1.1.0",
+        "undici": "7.14.0",
+        "workerd": "1.20251210.0",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/miniflare/node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/undici": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+      "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/workerd": {
+      "version": "1.20251210.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20251210.0.tgz",
+      "integrity": "sha512-9MUUneP1BnRE9XAYi94FXxHmiLGbO75EHQZsgWqSiOXjoXSqJCw8aQbIEPxCy19TclEl/kHUFYce8ST2W+Qpjw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20251210.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20251210.0",
+        "@cloudflare/workerd-linux-64": "1.20251210.0",
+        "@cloudflare/workerd-linux-arm64": "1.20251210.0",
+        "@cloudflare/workerd-windows-64": "1.20251210.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.54.0.tgz",
+      "integrity": "sha512-bANFsjDwJLbprYoBK+hUDZsVbUv2SqJd8QvArLIcZk+fPq4h/Ohtj5vkKXD3k0s2bD1DXLk08D+hYmeNH+xC6A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.1",
+        "@cloudflare/unenv-preset": "2.7.13",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.0",
+        "miniflare": "4.20251210.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20251210.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20251210.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
@@ -4319,6 +5517,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/dompurify": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
@@ -4410,6 +5626,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -4421,6 +5752,29 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -4507,6 +5861,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.3.tgz",
@@ -4547,6 +5911,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
+      "integrity": "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/blake3-wasm": {
@@ -4674,6 +6048,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4741,6 +6125,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -4752,6 +6153,23 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -4854,6 +6272,20 @@
       "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4871,6 +6303,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -5153,6 +6596,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -5225,6 +6678,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/devalue": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.2.tgz",
+      "integrity": "sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/diff": {
@@ -5392,6 +6852,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -5471,6 +6938,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -5525,6 +7002,29 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -5905,6 +7405,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -6671,6 +8178,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6771,6 +8285,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -7230,6 +8757,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8186,6 +9723,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8197,6 +9741,23 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -8262,6 +9823,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standardwebhooks": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
@@ -8281,6 +9849,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
@@ -8291,6 +9866,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
       }
     },
     "node_modules/string-width": {
@@ -8399,6 +9985,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -8474,6 +10080,67 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -8812,6 +10479,102 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -8832,6 +10595,23 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/workerd": {
       "version": "1.20260831.1",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,15 @@
     "dev:worker": "wrangler dev",
     "prebuild": "node scripts/gen-version.mjs",
     "build": "vite build",
-    "check": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.worker.json --noEmit",
+    "check": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.worker.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "deploy": "npm run build && wrangler deploy",
     "deploy:mine": "npm run build && wrangler deploy -c wrangler.local.jsonc",
     "db:migrate:local": "wrangler d1 migrations apply heyflare-db --local",
     "db:migrate": "wrangler d1 migrations apply heyflare-db --remote",
     "db:migrate:mine": "wrangler d1 migrations apply hey-db --remote -c wrangler.local.jsonc",
-    "db:migrate:mine:local": "wrangler d1 migrations apply hey-db --local -c wrangler.local.jsonc"
+    "db:migrate:mine:local": "wrangler d1 migrations apply hey-db --local -c wrangler.local.jsonc",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.123.0",
@@ -44,6 +46,7 @@
     "zod": "^4.5.4"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.10.0",
     "@cloudflare/workers-types": "^5.20260831.1",
     "@tailwindcss/vite": "^4.0.0",
     "@types/dompurify": "^3.0.5",
@@ -55,6 +58,7 @@
     "tailwindcss": "^4.0.0",
     "typescript": "^5.6.2",
     "vite": "^5.4.8",
+    "vitest": "^3.2.4",
     "wrangler": "^4.128.0"
   }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -25,7 +25,7 @@ export interface Account {
   id: string;
   email: string;
   display_name: string;
-  provider: "gmail" | "domain" | "outlook";
+  provider: "gmail" | "domain" | "outlook" | "imap";
   domain_id: string | null;
   initial_sync_done: boolean;
   initial_sync_count: number;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -25,7 +25,7 @@ export interface Account {
   id: string;
   email: string;
   display_name: string;
-  provider: "gmail" | "domain";
+  provider: "gmail" | "domain" | "outlook";
   domain_id: string | null;
   initial_sync_done: boolean;
   initial_sync_count: number;

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -503,6 +503,34 @@ export async function createDomain(body: { name: string; confirm?: boolean }): P
   if (!res.ok) throw new ApiError(res.status, DOMAIN_ERRORS[data?.error] ?? String(data?.error ?? res.statusText).replace(/_/g, " "));
   return data as T.Domain;
 }
+export interface OAuthCredentialStatus {
+  provider: "google" | "microsoft";
+  configured: boolean;
+  /** "env" means a Worker secret is set, so the stored value is ignored and the form is read-only. */
+  source: "env" | "db" | "none";
+  client_id: string;
+  secret_hint: string;
+}
+
+export function useOAuthCredentials() {
+  return useQuery({ queryKey: ["oauth"], queryFn: () => api.get<OAuthCredentialStatus[]>("/api/oauth"), staleTime: 30_000 });
+}
+
+export function useOAuthMutations() {
+  const qc = useQueryClient();
+  const inv = () => {
+    qc.invalidateQueries({ queryKey: ["oauth"] });
+    qc.invalidateQueries({ queryKey: keys.me });
+  };
+  return {
+    save: useMutation({
+      mutationFn: (b: { provider: string; client_id?: string; client_secret?: string | null }) =>
+        request<OAuthCredentialStatus>("PUT", `/api/oauth/${b.provider}`, { client_id: b.client_id, client_secret: b.client_secret }),
+      onSuccess: inv,
+    }),
+  };
+}
+
 export interface ImapDraft {
   email: string;
   display_name?: string;

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -152,6 +152,7 @@ export function removeThreadsFromLists(qc: QueryClient, ids: string[]) {
 export interface MeResponse {
   user: T.User | null;
   google_configured?: boolean;
+  microsoft_configured?: boolean;
   accounts: T.Account[];
   setup_required: boolean;
 }

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -506,8 +506,12 @@ export async function createDomain(body: { name: string; confirm?: boolean }): P
 export interface OAuthCredentialStatus {
   provider: "google" | "microsoft";
   configured: boolean;
-  /** "env" means a Worker secret is set, so the stored value is ignored and the form is read-only. */
+  /** Which credentials are in use right now. */
   source: "env" | "db" | "none";
+  /** A Worker secret exists for this provider, whether or not it is the one in use. */
+  env_available: boolean;
+  /** Stored credentials are deliberately overriding a Worker secret. */
+  overriding: boolean;
   client_id: string;
   secret_hint: string;
 }
@@ -524,8 +528,12 @@ export function useOAuthMutations() {
   };
   return {
     save: useMutation({
-      mutationFn: (b: { provider: string; client_id?: string; client_secret?: string | null }) =>
-        request<OAuthCredentialStatus>("PUT", `/api/oauth/${b.provider}`, { client_id: b.client_id, client_secret: b.client_secret }),
+      mutationFn: (b: { provider: string; client_id?: string; client_secret?: string | null; override_env?: boolean }) =>
+        request<OAuthCredentialStatus>("PUT", `/api/oauth/${b.provider}`, {
+          client_id: b.client_id,
+          client_secret: b.client_secret,
+          override_env: b.override_env,
+        }),
       onSuccess: inv,
     }),
   };

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -503,6 +503,37 @@ export async function createDomain(body: { name: string; confirm?: boolean }): P
   if (!res.ok) throw new ApiError(res.status, DOMAIN_ERRORS[data?.error] ?? String(data?.error ?? res.statusText).replace(/_/g, " "));
   return data as T.Domain;
 }
+export interface ImapDraft {
+  email: string;
+  display_name?: string;
+  imap_host: string;
+  imap_port: number;
+  imap_security: "tls" | "starttls";
+  smtp_host: string;
+  smtp_port: number;
+  smtp_security: "tls" | "starttls";
+  username?: string;
+  password: string;
+  folder?: string;
+}
+
+export function useImapMutations() {
+  const qc = useQueryClient();
+  const inv = () => {
+    qc.invalidateQueries({ queryKey: ["domains"] });
+    qc.invalidateQueries({ queryKey: keys.me });
+  };
+  return {
+    create: useMutation({
+      mutationFn: (b: ImapDraft) => api.post<{ ok: boolean; account: T.Account }>("/api/accounts/imap", b),
+      onSuccess: inv,
+    }),
+    test: useMutation({
+      mutationFn: (id: string) => api.post<{ ok: boolean; error?: string }>(`/api/accounts/${id}/imap/test`),
+    }),
+  };
+}
+
 export function useDomains(enabled = true) {
   return useQuery({ queryKey: ["domains"], queryFn: () => api.get<T.Domain[]>("/api/domains"), enabled, staleTime: 15_000 });
 }

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -564,6 +564,11 @@ export function useImapMutations() {
       mutationFn: (b: ImapDraft) => api.post<{ ok: boolean; account: T.Account }>("/api/accounts/imap", b),
       onSuccess: inv,
     }),
+    update: useMutation({
+      mutationFn: ({ id, ...b }: Partial<ImapDraft> & { id: string }) =>
+        request<{ ok: boolean; account: T.Account }>("PATCH", `/api/accounts/${id}/imap`, b),
+      onSuccess: inv,
+    }),
     test: useMutation({
       mutationFn: (id: string) => api.post<{ ok: boolean; error?: string }>(`/api/accounts/${id}/imap/test`),
     }),

--- a/src/web/components/CommandPalette.tsx
+++ b/src/web/components/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { startGoogleConnect } from "../lib/connect";
+import { startGoogleConnect, startMicrosoftConnect } from "../lib/connect";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { ArrowUpCircle, Bookmark, CalendarClock, CalendarDays, Clock, Eye, FileText, Files, FolderOpen, Inbox, Keyboard, Mail, Moon, NotebookPen, PenSquare, Plus, Repeat, Rss, Scissors, Send, Settings, Shield, ShieldOff, Sparkles, Sun, Tag, Trash2, Users } from "lucide-react";
@@ -74,6 +74,7 @@ export function CommandPalette({
       { id: "compose", label: "Compose a new message", icon: <PenSquare />, kbd: "c", run: onCompose, keywords: "write new email" },
       ...(onAssistant ? [{ id: "assistant", label: "Open the Assistant", icon: <Sparkles />, kbd: "⌘J", run: onAssistant, keywords: "ai chat help" }] : []),
       { id: "connect", label: "Connect a Gmail account", icon: <Plus />, run: () => startGoogleConnect(), keywords: "google add account" },
+      { id: "connect-ms", label: "Connect an Outlook account", icon: <Plus />, run: () => startMicrosoftConnect(), keywords: "microsoft outlook office365 add account" },
       { id: "theme", label: theme === "dark" ? "Switch to light theme" : "Switch to dark theme", icon: theme === "dark" ? <Sun /> : <Moon />, run: onToggleTheme, keywords: "dark light mode appearance" },
       { id: "shortcuts", label: "Keyboard shortcuts", icon: <Keyboard />, kbd: "?", run: onShortcuts },
     ],

--- a/src/web/components/CommandPalette.tsx
+++ b/src/web/components/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import { startGoogleConnect, startMicrosoftConnect } from "../lib/connect";
+import { useAccount } from "../context/AccountContext";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { ArrowUpCircle, Bookmark, CalendarClock, CalendarDays, Clock, Eye, FileText, Files, FolderOpen, Inbox, Keyboard, Mail, Moon, NotebookPen, PenSquare, Plus, Repeat, Rss, Scissors, Send, Settings, Shield, ShieldOff, Sparkles, Sun, Tag, Trash2, Users } from "lucide-react";
@@ -62,6 +63,7 @@ export function CommandPalette({
   hasAccount?: boolean;
 }) {
   const nav = useNavigate();
+  const { googleConfigured, microsoftConfigured } = useAccount();
   const [q, setQ] = useState("");
   const dq = useDebounced(q.trim(), 200);
   const search = useSearch(hasAccount && open ? dq : "");
@@ -73,12 +75,12 @@ export function CommandPalette({
     () => [
       { id: "compose", label: "Compose a new message", icon: <PenSquare />, kbd: "c", run: onCompose, keywords: "write new email" },
       ...(onAssistant ? [{ id: "assistant", label: "Open the Assistant", icon: <Sparkles />, kbd: "⌘J", run: onAssistant, keywords: "ai chat help" }] : []),
-      { id: "connect", label: "Connect a Gmail account", icon: <Plus />, run: () => startGoogleConnect(), keywords: "google add account" },
-      { id: "connect-ms", label: "Connect an Outlook account", icon: <Plus />, run: () => startMicrosoftConnect(), keywords: "microsoft outlook office365 add account" },
+      ...(googleConfigured ? [{ id: "connect", label: "Connect a Gmail account", icon: <Plus />, run: () => startGoogleConnect(), keywords: "google add account" }] : []),
+      ...(microsoftConfigured ? [{ id: "connect-ms", label: "Connect an Outlook account", icon: <Plus />, run: () => startMicrosoftConnect(), keywords: "microsoft outlook office365 add account" }] : []),
       { id: "theme", label: theme === "dark" ? "Switch to light theme" : "Switch to dark theme", icon: theme === "dark" ? <Sun /> : <Moon />, run: onToggleTheme, keywords: "dark light mode appearance" },
       { id: "shortcuts", label: "Keyboard shortcuts", icon: <Keyboard />, kbd: "?", run: onShortcuts },
     ],
-    [onCompose, onToggleTheme, onShortcuts, onAssistant, theme],
+    [onCompose, onToggleTheme, onShortcuts, onAssistant, theme, googleConfigured, microsoftConfigured],
   );
   const mail = dq ? (search.data?.pages.flatMap((p) => p.threads) ?? []).slice(0, 8) : [];
   const go = (fn: () => void) => {

--- a/src/web/components/Composer.tsx
+++ b/src/web/components/Composer.tsx
@@ -434,7 +434,7 @@ export const Composer = forwardRef<ComposerHandle, { initial?: ComposerInitial; 
                     <span className="inline-flex items-center gap-2 min-w-0">
                       <Avatar email={a.email} name={fromLabel(a)} src={a.avatar_url} size={16} />
                       <span className="truncate">{a.email}</span>
-                      <span className="text-xs text-muted-foreground">{a.provider === "domain" ? "Domain" : "Gmail"}</span>
+                      <span className="text-xs text-muted-foreground">{a.provider === "domain" ? "Domain" : a.provider === "outlook" ? "Outlook" : "Gmail"}</span>
                       {multi && <AccountGlyph glyph={glyphFor(a.id)} />}
                     </span>
                   </SelectItem>

--- a/src/web/components/Composer.tsx
+++ b/src/web/components/Composer.tsx
@@ -434,7 +434,7 @@ export const Composer = forwardRef<ComposerHandle, { initial?: ComposerInitial; 
                     <span className="inline-flex items-center gap-2 min-w-0">
                       <Avatar email={a.email} name={fromLabel(a)} src={a.avatar_url} size={16} />
                       <span className="truncate">{a.email}</span>
-                      <span className="text-xs text-muted-foreground">{a.provider === "domain" ? "Domain" : a.provider === "outlook" ? "Outlook" : "Gmail"}</span>
+                      <span className="text-xs text-muted-foreground">{a.provider === "domain" ? "Domain" : a.provider === "outlook" ? "Outlook" : a.provider === "imap" ? "IMAP" : "Gmail"}</span>
                       {multi && <AccountGlyph glyph={glyphFor(a.id)} />}
                     </span>
                   </SelectItem>

--- a/src/web/components/Shell.tsx
+++ b/src/web/components/Shell.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
 import { Mark } from "./Logo";
 import { isNative, isMac, native, onMenu, installExternalLinkHandler } from "../lib/native";
-import { startGoogleConnect } from "../lib/connect";
+import { startGoogleConnect, startMicrosoftConnect } from "../lib/connect";
 import { ALL, useAccount } from "../context/AccountContext";
 import { useCompose } from "../context/ComposeContext";
 import { api, useCounts, useMeMutations } from "../api";
@@ -435,11 +435,15 @@ function AppSidebar() {
                 </DropdownMenuRadioItem>
               ))}
             </DropdownMenuRadioGroup>
-            {accounts.length === 0 && <div className="px-2 py-1.5 text-xs text-muted-foreground">No Gmail connected yet.</div>}
+            {accounts.length === 0 && <div className="px-2 py-1.5 text-xs text-muted-foreground">Nothing connected yet.</div>}
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={() => startGoogleConnect()}>
               <Plus />
               Connect Gmail
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => startMicrosoftConnect()}>
+              <Plus />
+              Connect Outlook
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => nav("/settings#accounts")}>
               <Settings />

--- a/src/web/components/Shell.tsx
+++ b/src/web/components/Shell.tsx
@@ -221,7 +221,7 @@ function TopBar() {
 
 /* ---------------- sidebar ---------------- */
 function AppSidebar() {
-  const { user, accounts, account, scope, setScope, glyphFor } = useAccount();
+  const { user, accounts, account, scope, setScope, glyphFor, googleConfigured, microsoftConfigured } = useAccount();
   const counts = useCounts(accounts.length > 0);
   const update = useUpdateCheck();
   const { openCompose } = useCompose();
@@ -437,14 +437,18 @@ function AppSidebar() {
             </DropdownMenuRadioGroup>
             {accounts.length === 0 && <div className="px-2 py-1.5 text-xs text-muted-foreground">Nothing connected yet.</div>}
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => startGoogleConnect()}>
-              <Plus />
-              Connect Gmail
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => startMicrosoftConnect()}>
-              <Plus />
-              Connect Outlook
-            </DropdownMenuItem>
+{googleConfigured ? (
+              <DropdownMenuItem onClick={() => startGoogleConnect()}>
+                <Plus />
+                Connect Gmail
+              </DropdownMenuItem>
+            ) : null}
+            {microsoftConfigured ? (
+              <DropdownMenuItem onClick={() => startMicrosoftConnect()}>
+                <Plus />
+                Connect Outlook
+              </DropdownMenuItem>
+            ) : null}
             <DropdownMenuItem onClick={() => nav("/settings#accounts")}>
               <Settings />
               Manage accounts

--- a/src/web/context/AccountContext.tsx
+++ b/src/web/context/AccountContext.tsx
@@ -67,7 +67,8 @@ function applyTheme(theme: "light" | "dark" | "system") {
 function useSyncOnFocus(accounts: Account[], qc: ReturnType<typeof useQueryClient>) {
   const last = useRef(0);
   useEffect(() => {
-    const gmail = accounts.filter((a) => (a.provider === "gmail" || a.provider === "outlook") && a.sync_status !== "disconnected");
+    // Every polled provider, i.e. everything except a domain mailbox, which is pushed to instantly.
+    const gmail = accounts.filter((a) => a.provider !== "domain" && a.sync_status !== "disconnected");
     if (gmail.length === 0) return;
     const run = () => {
       if (document.visibilityState !== "visible") return;

--- a/src/web/context/AccountContext.tsx
+++ b/src/web/context/AccountContext.tsx
@@ -58,11 +58,11 @@ function applyTheme(theme: "light" | "dark" | "system") {
 }
 
 
-/** Kick a Gmail sync when the app is opened or regains focus (throttled), so mail feels live without any push setup. */
+/** Kick a sync when the app is opened or regains focus (throttled), so mail feels live without any push setup. */
 function useSyncOnFocus(accounts: Account[], qc: ReturnType<typeof useQueryClient>) {
   const last = useRef(0);
   useEffect(() => {
-    const gmail = accounts.filter((a) => a.provider === "gmail" && a.sync_status !== "disconnected");
+    const gmail = accounts.filter((a) => (a.provider === "gmail" || a.provider === "outlook") && a.sync_status !== "disconnected");
     if (gmail.length === 0) return;
     const run = () => {
       if (document.visibilityState !== "visible") return;

--- a/src/web/context/AccountContext.tsx
+++ b/src/web/context/AccountContext.tsx
@@ -21,6 +21,9 @@ interface Ctx {
   /** True when more than one account is connected (show glyphs). */
   multi: boolean;
   setupRequired: boolean;
+  /** False when no OAuth client is configured, so the UI can offer setup instead of a failing connect. */
+  googleConfigured: boolean;
+  microsoftConfigured: boolean;
   loading: boolean;
   error: Error | null;
   setScope: (scope: Scope) => void;
@@ -40,6 +43,8 @@ const AccountCtx = createContext<Ctx>({
   account: null,
   multi: false,
   setupRequired: false,
+  googleConfigured: false,
+  microsoftConfigured: false,
   loading: true,
   error: null,
   setScope: () => {},
@@ -146,6 +151,8 @@ export function AccountProvider({ children }: { children: ReactNode }) {
     account,
     multi: accounts.length > 1,
     setupRequired: me.data?.setup_required ?? false,
+    googleConfigured: me.data?.google_configured ?? false,
+    microsoftConfigured: me.data?.microsoft_configured ?? false,
     loading: me.isLoading,
     error: (me.error as Error) ?? null,
     setScope,

--- a/src/web/lib/connect.ts
+++ b/src/web/lib/connect.ts
@@ -32,7 +32,7 @@ function showWaitingOverlay(onDone: () => void) {
   el.className = "fixed inset-0 z-[1000] flex flex-col items-center justify-center gap-5 bg-background text-foreground px-6 text-center";
   el.innerHTML = `${MARK}
     <div class="max-w-xs space-y-1">
-      <div class="text-sm font-medium">Waiting for Google in your browser…</div>
+      <div class="text-sm font-medium">Waiting for your browser…</div>
       <div class="text-[13px] text-muted-foreground">Finish signing in there, then come back. Your account shows up on its own.</div>
     </div>
     <div class="flex items-center gap-2">
@@ -53,14 +53,14 @@ export function setConnectRefresh(fn: () => void) {
   refresh = fn;
 }
 
-async function startNative(hint?: string) {
+async function startNative(hint?: string, provider: "google" | "microsoft" = "google") {
   let url: string | undefined;
   try {
     const res = await fetch("/api/accounts/connect-link", {
       method: "POST",
       credentials: "include",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(hint ? { login_hint: hint } : {}),
+      body: JSON.stringify({ provider, ...(hint ? { login_hint: hint } : {}) }),
     });
     const data = (await res.json().catch(() => null)) as { url?: string; message?: string; error?: string } | null;
     if (!res.ok || !data?.url) throw new Error(data?.message || data?.error || "Couldn't start the Google flow.");
@@ -93,10 +93,16 @@ export function startGoogleConnect(hint?: string) {
 }
 
 /**
- * Microsoft needs no system-browser handoff: unlike Google it still signs people in inside embedded
- * web views, so the native app can run the consent screen in place and keep its session cookie.
+ * Microsoft goes through the same system-browser handoff as Google in the native apps. It is less
+ * strict about embedded web views than Google, but Conditional Access can still refuse one — and a
+ * connect that fails only for some tenants is worse than always using the path that works.
  */
 export function startMicrosoftConnect(hint?: string) {
+  if (isNative) {
+    showConnectOverlay("Opening your browser…");
+    void startNative(hint, "microsoft");
+    return;
+  }
   showConnectOverlay("Taking you to Microsoft…");
   const url = hint ? `/auth/microsoft/start?login_hint=${encodeURIComponent(hint)}` : "/auth/microsoft/start";
   requestAnimationFrame(() => setTimeout(() => (location.href = url), 30));

--- a/src/web/lib/connect.ts
+++ b/src/web/lib/connect.ts
@@ -92,6 +92,16 @@ export function startGoogleConnect(hint?: string) {
   requestAnimationFrame(() => setTimeout(() => (location.href = url), 30));
 }
 
+/**
+ * Microsoft needs no system-browser handoff: unlike Google it still signs people in inside embedded
+ * web views, so the native app can run the consent screen in place and keep its session cookie.
+ */
+export function startMicrosoftConnect(hint?: string) {
+  showConnectOverlay("Taking you to Microsoft…");
+  const url = hint ? `/auth/microsoft/start?login_hint=${encodeURIComponent(hint)}` : "/auth/microsoft/start";
+  requestAnimationFrame(() => setTimeout(() => (location.href = url), 30));
+}
+
 /** Intercepts every <a href="/auth/google/start…"> so Connect/Reconnect links take the right path. */
 export function installConnectInterceptor() {
   document.addEventListener("click", (e) => {

--- a/src/web/mobile/MobileSettings.tsx
+++ b/src/web/mobile/MobileSettings.tsx
@@ -15,7 +15,7 @@ import { useAccount } from "../context/AccountContext";
 import { Avatar, AccountGlyph } from "../components/Avatar";
 import { fmtRelative } from "../lib/format";
 import { startGoogleConnect, startMicrosoftConnect } from "../lib/connect";
-import { AddDomainDialog, CopyButton, Danger, DomainBadges, NewMailboxDialog, PreferencesSection, ProfileSection, SecuritySection, statusOf } from "../pages/Settings";
+import { AddDomainDialog, AddImapDialog, CopyButton, Danger, DomainBadges, NewMailboxDialog, PreferencesSection, ProfileSection, SecuritySection, statusOf } from "../pages/Settings";
 import { Screen } from "./Screen";
 import { ActionSheet } from "./ActionSheet";
 
@@ -173,14 +173,17 @@ function AccountRow({ a }: { a: Account }) {
 
 export function MobileSettingsAccounts() {
   const { accounts } = useAccount();
+  const [addImap, setAddImap] = useState(false);
   const remote = accounts.filter((a) => a.provider !== "domain");
   const boxes = accounts.filter((a) => a.provider === "domain");
   return (
     <Sub title="Accounts">
+      <AddImapDialog open={addImap} onOpenChange={setAddImap} variant="drawer" />
       <Group title="Connected accounts" footer={remote.length === 0 ? "Nothing connected yet." : undefined}>
         {remote.map((a) => <AccountRow key={a.id} a={a} />)}
         <Row icon={<Plus />} label="Connect Gmail" onClick={() => startGoogleConnect()} chevron={false} />
         <Row icon={<Plus />} label="Connect Outlook" onClick={() => startMicrosoftConnect()} chevron={false} />
+        <Row icon={<Plus />} label="Add mailbox (IMAP)" onClick={() => setAddImap(true)} chevron={false} />
       </Group>
       <Group title="Domain mailboxes" footer={boxes.length === 0 ? "No mailboxes yet. Add a domain first." : undefined}>
         {boxes.map((a) => <AccountRow key={a.id} a={a} />)}

--- a/src/web/mobile/MobileSettings.tsx
+++ b/src/web/mobile/MobileSettings.tsx
@@ -172,7 +172,7 @@ function AccountRow({ a }: { a: Account }) {
 }
 
 export function MobileSettingsAccounts() {
-  const { accounts } = useAccount();
+  const { accounts, googleConfigured, microsoftConfigured } = useAccount();
   const [addImap, setAddImap] = useState(false);
   const remote = accounts.filter((a) => a.provider !== "domain");
   const boxes = accounts.filter((a) => a.provider === "domain");
@@ -181,8 +181,8 @@ export function MobileSettingsAccounts() {
       <AddImapDialog open={addImap} onOpenChange={setAddImap} variant="drawer" />
       <Group title="Connected accounts" footer={remote.length === 0 ? "Nothing connected yet." : undefined}>
         {remote.map((a) => <AccountRow key={a.id} a={a} />)}
-        <Row icon={<Plus />} label="Connect Gmail" onClick={() => startGoogleConnect()} chevron={false} />
-        <Row icon={<Plus />} label="Connect Outlook" onClick={() => startMicrosoftConnect()} chevron={false} />
+{googleConfigured ? <Row icon={<Plus />} label="Connect Gmail" onClick={() => startGoogleConnect()} chevron={false} /> : null}
+        {microsoftConfigured ? <Row icon={<Plus />} label="Connect Outlook" onClick={() => startMicrosoftConnect()} chevron={false} /> : null}
         <Row icon={<Plus />} label="Add mailbox (IMAP)" onClick={() => setAddImap(true)} chevron={false} />
       </Group>
       <Group title="Domain mailboxes" footer={boxes.length === 0 ? "No mailboxes yet. Add a domain first." : undefined}>

--- a/src/web/mobile/MobileSettings.tsx
+++ b/src/web/mobile/MobileSettings.tsx
@@ -14,7 +14,7 @@ import { api, domainErrorMessage, useAccountMutations, useDomainMutations, useDo
 import { useAccount } from "../context/AccountContext";
 import { Avatar, AccountGlyph } from "../components/Avatar";
 import { fmtRelative } from "../lib/format";
-import { startGoogleConnect } from "../lib/connect";
+import { startGoogleConnect, startMicrosoftConnect } from "../lib/connect";
 import { AddDomainDialog, CopyButton, Danger, DomainBadges, NewMailboxDialog, PreferencesSection, ProfileSection, SecuritySection, statusOf } from "../pages/Settings";
 import { Screen } from "./Screen";
 import { ActionSheet } from "./ActionSheet";
@@ -164,7 +164,7 @@ function AccountRow({ a }: { a: Account }) {
         <span className="inline-flex items-center gap-1.5">
           {st.spin && <RefreshCw size={11} className="animate-spin" />}
           {st.label}
-          {a.provider === "gmail" && a.last_synced_at && <span>· {fmtRelative(a.last_synced_at)}</span>}
+          {a.provider !== "domain" && a.last_synced_at && <span>· {fmtRelative(a.last_synced_at)}</span>}
         </span>
       }
     />
@@ -173,13 +173,14 @@ function AccountRow({ a }: { a: Account }) {
 
 export function MobileSettingsAccounts() {
   const { accounts } = useAccount();
-  const gmail = accounts.filter((a) => a.provider !== "domain");
+  const remote = accounts.filter((a) => a.provider !== "domain");
   const boxes = accounts.filter((a) => a.provider === "domain");
   return (
     <Sub title="Accounts">
-      <Group title="Gmail" footer={gmail.length === 0 ? "No Gmail connected yet." : undefined}>
-        {gmail.map((a) => <AccountRow key={a.id} a={a} />)}
+      <Group title="Connected accounts" footer={remote.length === 0 ? "Nothing connected yet." : undefined}>
+        {remote.map((a) => <AccountRow key={a.id} a={a} />)}
         <Row icon={<Plus />} label="Connect Gmail" onClick={() => startGoogleConnect()} chevron={false} />
+        <Row icon={<Plus />} label="Connect Outlook" onClick={() => startMicrosoftConnect()} chevron={false} />
       </Group>
       <Group title="Domain mailboxes" footer={boxes.length === 0 ? "No mailboxes yet. Add a domain first." : undefined}>
         {boxes.map((a) => <AccountRow key={a.id} a={a} />)}
@@ -202,7 +203,7 @@ export function MobileSettingsAccountDetail() {
   useEffect(() => { if (a) { setSignature(a.signature); setDisplayName(a.display_name); } }, [a?.signature, a?.display_name]); // eslint-disable-line react-hooks/exhaustive-deps
   if (!a) return <Navigate to="/settings/accounts" replace />;
   const st = statusOf(a);
-  const isGmail = a.provider === "gmail";
+  const isGmail = a.provider === "gmail" || a.provider === "outlook";
   const dirty = signature !== a.signature || displayName !== a.display_name;
   const save = () => update.mutate({ id: a.id, signature, display_name: displayName }, { onSuccess: () => toast("Saved"), onError: (e) => toast.error((e as Error).message) });
   return (

--- a/src/web/mobile/MobileShell.tsx
+++ b/src/web/mobile/MobileShell.tsx
@@ -23,7 +23,7 @@ export function MobileShell() {
 
 /** Account scope picker as a bottom sheet (tap the Imbox title). */
 export function ScopeSheet({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
-  const { accounts, scope, setScope, glyphFor } = useAccount();
+  const { accounts, scope, setScope, glyphFor, googleConfigured, microsoftConfigured } = useAccount();
   const nav = useNavigate();
   return (
     <ActionSheet
@@ -33,8 +33,8 @@ export function ScopeSheet({ open, onOpenChange }: { open: boolean; onOpenChange
       actions={[
         { icon: <Layers />, label: "All accounts", hint: accounts.length > 1 ? accounts.length : undefined, checked: scope === ALL, onSelect: () => { setScope(ALL); nav("/"); } },
         ...accounts.map((a) => ({ icon: <span className="text-[13px] w-5 text-center">{glyphFor(a.id)}</span>, label: a.email, checked: scope === a.id, onSelect: () => { setScope(a.id); nav("/"); } })),
-        { icon: <Plus />, label: "Connect Gmail", onSelect: () => startGoogleConnect() },
-        { icon: <Plus />, label: "Connect Outlook", onSelect: () => startMicrosoftConnect() },
+...(googleConfigured ? [{ icon: <Plus />, label: "Connect Gmail", onSelect: () => startGoogleConnect() }] : []),
+        ...(microsoftConfigured ? [{ icon: <Plus />, label: "Connect Outlook", onSelect: () => startMicrosoftConnect() }] : []),
         { icon: <Settings />, label: "Manage accounts", onSelect: () => nav("/settings#accounts") },
       ]}
     />

--- a/src/web/mobile/MobileShell.tsx
+++ b/src/web/mobile/MobileShell.tsx
@@ -2,7 +2,7 @@ import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { Layers, Plus, Settings } from "lucide-react";
 import { Mark } from "../components/Logo";
 import { ALL, useAccount } from "../context/AccountContext";
-import { startGoogleConnect } from "../lib/connect";
+import { startGoogleConnect, startMicrosoftConnect } from "../lib/connect";
 import { ActionSheet } from "./ActionSheet";
 import { useNavigate } from "react-router-dom";
 
@@ -34,6 +34,7 @@ export function ScopeSheet({ open, onOpenChange }: { open: boolean; onOpenChange
         { icon: <Layers />, label: "All accounts", hint: accounts.length > 1 ? accounts.length : undefined, checked: scope === ALL, onSelect: () => { setScope(ALL); nav("/"); } },
         ...accounts.map((a) => ({ icon: <span className="text-[13px] w-5 text-center">{glyphFor(a.id)}</span>, label: a.email, checked: scope === a.id, onSelect: () => { setScope(a.id); nav("/"); } })),
         { icon: <Plus />, label: "Connect Gmail", onSelect: () => startGoogleConnect() },
+        { icon: <Plus />, label: "Connect Outlook", onSelect: () => startMicrosoftConnect() },
         { icon: <Settings />, label: "Manage accounts", onSelect: () => nav("/settings#accounts") },
       ]}
     />

--- a/src/web/mobile/MobileThread.tsx
+++ b/src/web/mobile/MobileThread.tsx
@@ -355,7 +355,7 @@ export default function MobileThread() {
         <AlertDialogContent size="sm">
           <AlertDialogHeader>
             <AlertDialogTitle>Delete this thread forever?</AlertDialogTitle>
-            <AlertDialogDescription>It'll be removed here and trashed in {account?.provider === "domain" ? "your mailbox" : account?.provider === "outlook" ? "Outlook" : "Gmail"}. There's no undo.</AlertDialogDescription>
+            <AlertDialogDescription>It'll be removed here and trashed in {account?.provider === "domain" || account?.provider === "imap" ? "your mailbox" : account?.provider === "outlook" ? "Outlook" : "Gmail"}. There's no undo.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>

--- a/src/web/mobile/MobileThread.tsx
+++ b/src/web/mobile/MobileThread.tsx
@@ -355,7 +355,7 @@ export default function MobileThread() {
         <AlertDialogContent size="sm">
           <AlertDialogHeader>
             <AlertDialogTitle>Delete this thread forever?</AlertDialogTitle>
-            <AlertDialogDescription>It'll be removed here and trashed in {account?.provider === "domain" ? "your mailbox" : "Gmail"}. There's no undo.</AlertDialogDescription>
+            <AlertDialogDescription>It'll be removed here and trashed in {account?.provider === "domain" ? "your mailbox" : account?.provider === "outlook" ? "Outlook" : "Gmail"}. There's no undo.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>

--- a/src/web/pages/Settings.tsx
+++ b/src/web/pages/Settings.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { AlertTriangle, CalendarDays, Check, ChevronDown, Copy, FileText, Globe, Inbox, KeyRound, Mail, Monitor, Moon, Plus, RefreshCw, Rss, ShieldCheck, SlidersHorizontal, Sun, Trash2, Unplug, User, Sparkles } from "lucide-react";
+import { AlertTriangle, CalendarDays, Check, ChevronDown, Copy, FileText, Globe, Inbox, KeyRound, Mail, Monitor, Moon, Plus, RefreshCw, Rss, ShieldCheck, SlidersHorizontal, Sun, Trash2, Unplug, User, Sparkles, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import type { Account, Domain, UserSettings } from "@shared/types";
 import { cn } from "@/lib/utils";
 import { useAccount } from "../context/AccountContext";
-import { DomainMxError, domainErrorMessage, useAccountMutations, useDomainMutations, useDomains, useMeMutations, useTwoFactor, useTwoFactorMutations } from "../api";
+import { DomainMxError, domainErrorMessage, useAccountMutations, useDomainMutations, useDomains, useMeMutations, useTwoFactor, useTwoFactorMutations, useImapMutations } from "../api";
 import QRCode from "qrcode";
 import { Avatar, AccountGlyph } from "../components/Avatar";
 import { PageHeader } from "../components/EmptyState";
@@ -157,6 +157,7 @@ function FormShell({ open, onClose, title, description, footer, variant = "dialo
 
 export function statusOf(a: Account): { label: string; spin?: boolean } {
   if (a.provider === "domain") return { label: "Mailbox · receives via Cloudflare" };
+  if (a.provider === "imap" && a.sync_status === "idle") return { label: "Mailbox · IMAP" };
   if (a.sync_status === "disconnected") return { label: "Disconnected" };
   if (a.sync_status === "error") return { label: "Sync error" };
   if (!a.initial_sync_done) return { label: "Connecting", spin: true };
@@ -670,12 +671,151 @@ export function PreferencesSection({ compact }: { compact?: boolean }) {
   );
 }
 
+/**
+ * Common providers, so nobody has to look up host names. "Other" leaves the fields blank for a
+ * cPanel-style webmail host, which is usually mail.<your-domain>.
+ */
+const IMAP_PRESETS: { id: string; label: string; imap_host: string; smtp_host: string; note?: string }[] = [
+  { id: "zoho", label: "Zoho Mail", imap_host: "imap.zoho.com", smtp_host: "smtp.zoho.com", note: "Enable IMAP in Zoho settings, and use an app password if two-factor is on." },
+  { id: "fastmail", label: "Fastmail", imap_host: "imap.fastmail.com", smtp_host: "smtp.fastmail.com", note: "Create an app password in Fastmail under Settings → Privacy & Security." },
+  { id: "migadu", label: "Migadu", imap_host: "imap.migadu.com", smtp_host: "smtp.migadu.com" },
+  { id: "other", label: "Other / webmail", imap_host: "", smtp_host: "", note: "For cPanel-style hosting this is usually mail.yourdomain.com on 993 and 465." },
+];
+
+export function AddImapDialog({ open, onOpenChange, variant = "dialog" }: { open: boolean; onOpenChange: (o: boolean) => void; variant?: "dialog" | "drawer" }) {
+  const { create } = useImapMutations();
+  const [preset, setPreset] = useState("zoho");
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [password, setPassword] = useState("");
+  const [imapHost, setImapHost] = useState("imap.zoho.com");
+  const [smtpHost, setSmtpHost] = useState("smtp.zoho.com");
+  const [imapPort, setImapPort] = useState(993);
+  const [smtpPort, setSmtpPort] = useState(465);
+  const [smtpSecurity, setSmtpSecurity] = useState<"tls" | "starttls">("tls");
+  const [advanced, setAdvanced] = useState(false);
+
+  const pickPreset = (id: string) => {
+    setPreset(id);
+    const pr = IMAP_PRESETS.find((x) => x.id === id)!;
+    setImapHost(pr.imap_host);
+    setSmtpHost(pr.smtp_host);
+    setImapPort(993);
+    setSmtpPort(465);
+    setSmtpSecurity("tls");
+  };
+
+  const close = () => {
+    onOpenChange(false);
+    setEmail(""); setName(""); setPassword(""); setAdvanced(false);
+  };
+
+  const submit = () =>
+    create.mutate(
+      {
+        email: email.trim().toLowerCase(),
+        display_name: name.trim(),
+        imap_host: imapHost.trim(),
+        imap_port: imapPort,
+        imap_security: "tls",
+        smtp_host: smtpHost.trim(),
+        smtp_port: smtpPort,
+        smtp_security: smtpSecurity,
+        password,
+      },
+      {
+        onSuccess: (r: { account: { email: string } }) => { toast(`${r.account.email} is connected`); close(); },
+        onError: (e: unknown) => toast.error("Couldn't connect", { description: (e as Error).message, duration: 12000 }),
+      }
+    );
+
+  const mobile = variant === "drawer";
+  const note = IMAP_PRESETS.find((x) => x.id === preset)?.note;
+  const ready = email.trim() && password && imapHost.trim() && smtpHost.trim();
+
+  return (
+    <FormShell
+      open={open}
+      onClose={close}
+      variant={variant}
+      title="Add a mailbox"
+      description="Connect any mailbox that speaks IMAP and SMTP — Zoho, Fastmail, Migadu or your own webmail."
+      footer={
+        <>
+          <Button type="button" variant="ghost" size={mobile ? "lg" : "default"} onClick={close}>Cancel</Button>
+          <Button type="button" size={mobile ? "lg" : "default"} disabled={!ready || create.isPending} onClick={submit}>
+            {create.isPending ? <Loader2 className="animate-spin" /> : null} Connect
+          </Button>
+        </>
+      }
+    >
+      <form onSubmit={(e) => { e.preventDefault(); if (ready) submit(); }}>
+        <FieldGroup>
+          <Field>
+            <FieldLabel htmlFor="imap-preset">Provider</FieldLabel>
+            <select id="imap-preset" value={preset} onChange={(e) => pickPreset(e.target.value)} className={cn("rounded-md bg-input px-2.5 outline-none focus:bg-background focus:ring-1 focus:ring-ring", mobile ? "h-11 text-[16px]" : "h-8 text-sm")}>
+              {IMAP_PRESETS.map((pr) => <option key={pr.id} value={pr.id}>{pr.label}</option>)}
+            </select>
+            {note ? <FieldDescription>{note}</FieldDescription> : null}
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="imap-email">Email address</FieldLabel>
+            <Input id="imap-email" type="email" autoComplete="off" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="you@example.com" className={cn(mobile && "h-11 text-[16px]")} required />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="imap-name">Display name</FieldLabel>
+            <Input id="imap-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Sanjay" className={cn(mobile && "h-11 text-[16px]")} />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="imap-pass">Password</FieldLabel>
+            <Input id="imap-pass" type="password" autoComplete="off" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="App password" className={cn(mobile && "h-11 text-[16px]")} required />
+            <FieldDescription>Stored encrypted on your server and never shown again. Use an app-specific password where your provider offers one.</FieldDescription>
+          </Field>
+
+          <Field orientation="horizontal">
+            <Switch id="imap-adv" checked={advanced} onCheckedChange={setAdvanced} />
+            <div>
+              <FieldLabel htmlFor="imap-adv">Server settings</FieldLabel>
+              <FieldDescription>Only needed for a host that is not in the list above.</FieldDescription>
+            </div>
+          </Field>
+
+          {advanced ? (
+            <>
+              <Field>
+                <FieldLabel htmlFor="imap-host">IMAP server</FieldLabel>
+                <div className="flex gap-2">
+                  <Input id="imap-host" value={imapHost} onChange={(e) => setImapHost(e.target.value)} placeholder="imap.example.com" className={cn("flex-1", mobile && "h-11 text-[16px]")} />
+                  <Input aria-label="IMAP port" type="number" value={imapPort} onChange={(e) => setImapPort(Number(e.target.value))} className={cn("w-24", mobile && "h-11 text-[16px]")} />
+                </div>
+                <FieldDescription>993 with implicit TLS.</FieldDescription>
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="smtp-host">SMTP server</FieldLabel>
+                <div className="flex gap-2">
+                  <Input id="smtp-host" value={smtpHost} onChange={(e) => setSmtpHost(e.target.value)} placeholder="smtp.example.com" className={cn("flex-1", mobile && "h-11 text-[16px]")} />
+                  <Input aria-label="SMTP port" type="number" value={smtpPort} onChange={(e) => { const v = Number(e.target.value); setSmtpPort(v); setSmtpSecurity(v === 587 ? "starttls" : "tls"); }} className={cn("w-24", mobile && "h-11 text-[16px]")} />
+                </div>
+                <FieldDescription>
+                  465 for implicit TLS, or 587 for STARTTLS. Port 25 is blocked by Cloudflare and cannot be used.
+                </FieldDescription>
+              </Field>
+            </>
+          ) : null}
+        </FieldGroup>
+      </form>
+    </FormShell>
+  );
+}
+
 export function AccountsSection({ onNewMailbox }: { onNewMailbox?: () => void }) {
   const { accounts } = useAccount();
+  const [addImap, setAddImap] = useState(false);
   const remote = accounts.filter((a) => a.provider !== "domain");
   const boxes = accounts.filter((a) => a.provider === "domain");
   return (
     <>
+      <AddImapDialog open={addImap} onOpenChange={setAddImap} />
       <Section
         title="Connected accounts"
         description="What's connected, and how it signs off."
@@ -683,6 +823,7 @@ export function AccountsSection({ onNewMailbox }: { onNewMailbox?: () => void })
           <div className="flex items-center gap-1">
             <Button size="sm" variant="ghost" className="text-muted-foreground" asChild><a href="/auth/google/start"><Plus /> Connect Gmail</a></Button>
             <Button size="sm" variant="ghost" className="text-muted-foreground" asChild><a href="/auth/microsoft/start"><Plus /> Connect Outlook</a></Button>
+            <Button size="sm" variant="ghost" className="text-muted-foreground" onClick={() => setAddImap(true)}><Plus /> Add mailbox</Button>
           </div>
         }
       >

--- a/src/web/pages/Settings.tsx
+++ b/src/web/pages/Settings.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import type { Account, Domain, UserSettings } from "@shared/types";
 import { cn } from "@/lib/utils";
 import { useAccount } from "../context/AccountContext";
-import { DomainMxError, domainErrorMessage, useAccountMutations, useDomainMutations, useDomains, useMeMutations, useTwoFactor, useTwoFactorMutations, useImapMutations, useOAuthCredentials, useOAuthMutations, type OAuthCredentialStatus } from "../api";
+import { DomainMxError, domainErrorMessage, useAccountMutations, useDomainMutations, useDomains, useMeMutations, useTwoFactor, useTwoFactorMutations, useImapMutations, api, useOAuthCredentials, useOAuthMutations, type OAuthCredentialStatus } from "../api";
 import QRCode from "qrcode";
 import { Avatar, AccountGlyph } from "../components/Avatar";
 import { PageHeader } from "../components/EmptyState";
@@ -174,6 +174,7 @@ function AccountBlock({ a }: { a: Account }) {
   const [displayName, setDisplayName] = useState(a.display_name);
   const [confirm, setConfirm] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [editImap, setEditImap] = useState(false);
   useEffect(() => { setSignature(a.signature); setDisplayName(a.display_name); }, [a.signature, a.display_name]);
   const dirty = signature !== a.signature || displayName !== a.display_name;
   const st = statusOf(a);
@@ -185,6 +186,7 @@ function AccountBlock({ a }: { a: Account }) {
     );
   return (
     <Collapsible open={open} onOpenChange={setOpen} className="border-b border-border last:border-b-0">
+      {a.provider === "imap" ? <EditImapDialog account={a} open={editImap} onOpenChange={setEditImap} /> : null}
       <div className="flex items-center gap-3 px-2 h-12">
         <Avatar email={a.email} name={a.display_name} src={a.avatar_url} size={24} />
         <div className="flex-1 min-w-0">
@@ -234,6 +236,11 @@ function AccountBlock({ a }: { a: Account }) {
             <Button size="sm" onClick={save} disabled={!dirty || update.isPending}>Save</Button>
             <SavedMark show={saved && !dirty} />
             <span className="flex-1" />
+            {a.provider === "imap" && (
+              <Button size="sm" variant="ghost" className="text-muted-foreground" onClick={() => setEditImap(true)}>
+                <SlidersHorizontal /> Server settings
+              </Button>
+            )}
             {isGmail && (
               <Button size="sm" variant="ghost" className="text-muted-foreground" disabled={reset.isPending} onClick={() => setConfirmReset(true)}>
                 <RefreshCw /> Start fresh
@@ -668,6 +675,87 @@ export function PreferencesSection({ compact }: { compact?: boolean }) {
         </Row>
       </Section>
     </>
+  );
+}
+
+/** Change an IMAP mailbox's server settings or password without losing its synced mail. */
+export function EditImapDialog({ account, open, onOpenChange, variant = "dialog" }: { account: Account; open: boolean; onOpenChange: (o: boolean) => void; variant?: "dialog" | "drawer" }) {
+  const { update, test } = useImapMutations();
+  const [imapHost, setImapHost] = useState("");
+  const [smtpHost, setSmtpHost] = useState("");
+  const [imapPort, setImapPort] = useState(993);
+  const [smtpPort, setSmtpPort] = useState(465);
+  const [password, setPassword] = useState("");
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!open || loaded) return;
+    void (async () => {
+      try {
+        const r = await api.get<{ imap_host: string; imap_port: number; smtp_host: string; smtp_port: number }>(`/api/accounts/${account.id}/imap`);
+        setImapHost(r.imap_host); setImapPort(r.imap_port); setSmtpHost(r.smtp_host); setSmtpPort(r.smtp_port);
+        setLoaded(true);
+      } catch (e) { toast.error((e as Error).message); }
+    })();
+  }, [open, loaded, account.id]);
+
+  const close = () => { onOpenChange(false); setPassword(""); setLoaded(false); };
+  const submit = () =>
+    update.mutate(
+      { id: account.id, imap_host: imapHost.trim(), imap_port: imapPort, smtp_host: smtpHost.trim(), smtp_port: smtpPort,
+        smtp_security: smtpPort === 587 ? "starttls" : "tls", ...(password.trim() ? { password: password.trim() } : {}) },
+      { onSuccess: () => { toast(`${account.email} updated`); close(); },
+        onError: (e: unknown) => toast.error("Couldn't connect", { description: (e as Error).message, duration: 12000 }) }
+    );
+
+  const mobile = variant === "drawer";
+  return (
+    <FormShell
+      open={open}
+      onClose={close}
+      variant={variant}
+      title={`Edit ${account.email}`}
+      description="Checked against both servers before anything is saved. Your mail is kept."
+      footer={
+        <>
+          <Button type="button" variant="ghost" size={mobile ? "lg" : "default"} onClick={close}>Cancel</Button>
+          <Button type="button" size={mobile ? "lg" : "default"} disabled={!loaded || update.isPending} onClick={submit}>
+            {update.isPending ? <Loader2 className="animate-spin" /> : null} Save
+          </Button>
+        </>
+      }
+    >
+      <FieldGroup>
+        <Field>
+          <FieldLabel htmlFor="e-pass">Password</FieldLabel>
+          <Input id="e-pass" type="password" autoComplete="off" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Leave blank to keep the current one" className={cn(mobile && "h-11 text-[16px]")} />
+          <FieldDescription>Set this when your provider's app password has been rotated.</FieldDescription>
+        </Field>
+        <Field>
+          <FieldLabel htmlFor="e-imap">IMAP server</FieldLabel>
+          <div className="flex gap-2">
+            <Input id="e-imap" value={imapHost} onChange={(e) => setImapHost(e.target.value)} className={cn("flex-1", mobile && "h-11 text-[16px]")} />
+            <Input aria-label="IMAP port" type="number" value={imapPort} onChange={(e) => setImapPort(Number(e.target.value))} className={cn("w-24", mobile && "h-11 text-[16px]")} />
+          </div>
+        </Field>
+        <Field>
+          <FieldLabel htmlFor="e-smtp">SMTP server</FieldLabel>
+          <div className="flex gap-2">
+            <Input id="e-smtp" value={smtpHost} onChange={(e) => setSmtpHost(e.target.value)} className={cn("flex-1", mobile && "h-11 text-[16px]")} />
+            <Input aria-label="SMTP port" type="number" value={smtpPort} onChange={(e) => setSmtpPort(Number(e.target.value))} className={cn("w-24", mobile && "h-11 text-[16px]")} />
+          </div>
+          <FieldDescription>465 for implicit TLS, 587 for STARTTLS. Port 25 is blocked by Cloudflare.</FieldDescription>
+        </Field>
+        <div>
+          <Button size="sm" variant="outline" disabled={test.isPending} onClick={() => test.mutate(account.id, {
+            onSuccess: (r: { ok: boolean; error?: string }) => (r.ok ? toast("Both servers answered") : toast.error(r.error ?? "Failed")),
+            onError: (e: unknown) => toast.error((e as Error).message),
+          })}>
+            {test.isPending ? <Loader2 className="animate-spin" /> : null} Test stored credentials
+          </Button>
+        </div>
+      </FieldGroup>
+    </FormShell>
   );
 }
 

--- a/src/web/pages/Settings.tsx
+++ b/src/web/pages/Settings.tsx
@@ -676,7 +676,8 @@ export function PreferencesSection({ compact }: { compact?: boolean }) {
  * cPanel-style webmail host, which is usually mail.<your-domain>.
  */
 const IMAP_PRESETS: { id: string; label: string; imap_host: string; smtp_host: string; note?: string }[] = [
-  { id: "zoho", label: "Zoho Mail", imap_host: "imap.zoho.com", smtp_host: "smtp.zoho.com", note: "Enable IMAP in Zoho settings, and use an app password if two-factor is on." },
+  { id: "zoho", label: "Zoho Mail (personal @zohomail.com)", imap_host: "imap.zoho.com", smtp_host: "smtp.zoho.com", note: "Enable IMAP under Settings → Mail Accounts, and use an app password if two-factor is on. IMAP needs a paid plan — the free plan is browser-only." },
+  { id: "zoho-pro", label: "Zoho Mail (your own domain)", imap_host: "imappro.zoho.com", smtp_host: "smtppro.zoho.com", note: "Organisation accounts on a custom domain use the 'pro' servers. On a non-US data centre swap .com for .eu, .in or .com.au." },
   { id: "fastmail", label: "Fastmail", imap_host: "imap.fastmail.com", smtp_host: "smtp.fastmail.com", note: "Create an app password in Fastmail under Settings → Privacy & Security." },
   { id: "migadu", label: "Migadu", imap_host: "imap.migadu.com", smtp_host: "smtp.migadu.com" },
   { id: "other", label: "Other / webmail", imap_host: "", smtp_host: "", note: "For cPanel-style hosting this is usually mail.yourdomain.com on 993 and 465." },

--- a/src/web/pages/Settings.tsx
+++ b/src/web/pages/Settings.tsx
@@ -176,7 +176,7 @@ function AccountBlock({ a }: { a: Account }) {
   useEffect(() => { setSignature(a.signature); setDisplayName(a.display_name); }, [a.signature, a.display_name]);
   const dirty = signature !== a.signature || displayName !== a.display_name;
   const st = statusOf(a);
-  const isGmail = a.provider === "gmail";
+  const isGmail = a.provider === "gmail" || a.provider === "outlook";
   const save = () =>
     update.mutate(
       { id: a.id, signature, display_name: displayName },
@@ -672,19 +672,24 @@ export function PreferencesSection({ compact }: { compact?: boolean }) {
 
 export function AccountsSection({ onNewMailbox }: { onNewMailbox?: () => void }) {
   const { accounts } = useAccount();
-  const gmail = accounts.filter((a) => a.provider !== "domain");
+  const remote = accounts.filter((a) => a.provider !== "domain");
   const boxes = accounts.filter((a) => a.provider === "domain");
   return (
     <>
       <Section
-        title="Gmail accounts"
+        title="Connected accounts"
         description="What's connected, and how it signs off."
-        actions={<Button size="sm" variant="ghost" className="text-muted-foreground" asChild><a href="/auth/google/start"><Plus /> Connect Gmail</a></Button>}
+        actions={
+          <div className="flex items-center gap-1">
+            <Button size="sm" variant="ghost" className="text-muted-foreground" asChild><a href="/auth/google/start"><Plus /> Connect Gmail</a></Button>
+            <Button size="sm" variant="ghost" className="text-muted-foreground" asChild><a href="/auth/microsoft/start"><Plus /> Connect Outlook</a></Button>
+          </div>
+        }
       >
-        {gmail.length === 0 ? (
-          <div className="px-2 py-2 text-[13px] text-muted-foreground">No Gmail connected yet.</div>
+        {remote.length === 0 ? (
+          <div className="px-2 py-2 text-[13px] text-muted-foreground">Nothing connected yet.</div>
         ) : (
-          <div>{gmail.map((a) => <AccountBlock key={a.id} a={a} />)}</div>
+          <div>{remote.map((a) => <AccountBlock key={a.id} a={a} />)}</div>
         )}
       </Section>
       <Section

--- a/src/web/pages/Settings.tsx
+++ b/src/web/pages/Settings.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import type { Account, Domain, UserSettings } from "@shared/types";
 import { cn } from "@/lib/utils";
 import { useAccount } from "../context/AccountContext";
-import { DomainMxError, domainErrorMessage, useAccountMutations, useDomainMutations, useDomains, useMeMutations, useTwoFactor, useTwoFactorMutations, useImapMutations } from "../api";
+import { DomainMxError, domainErrorMessage, useAccountMutations, useDomainMutations, useDomains, useMeMutations, useTwoFactor, useTwoFactorMutations, useImapMutations, useOAuthCredentials, useOAuthMutations, type OAuthCredentialStatus } from "../api";
 import QRCode from "qrcode";
 import { Avatar, AccountGlyph } from "../components/Avatar";
 import { PageHeader } from "../components/EmptyState";
@@ -809,6 +809,82 @@ export function AddImapDialog({ open, onOpenChange, variant = "dialog" }: { open
   );
 }
 
+const PROVIDER_LABELS: Record<string, { name: string; hint: string; docs: string }> = {
+  google: { name: "Google", hint: "Client ID and secret from the Google Cloud OAuth client.", docs: "https://console.cloud.google.com/apis/credentials" },
+  microsoft: { name: "Microsoft", hint: "Application (client) ID and a client secret from your Entra app registration.", docs: "https://portal.azure.com" },
+};
+
+function CredentialRow({ c, compact }: { c: OAuthCredentialStatus; compact?: boolean }) {
+  const { save } = useOAuthMutations();
+  const meta = PROVIDER_LABELS[c.provider];
+  const managed = c.source === "env";
+  const [clientId, setClientId] = useState(c.client_id);
+  const [secret, setSecret] = useState("");
+  const [dirty, setDirty] = useState(false);
+  useEffect(() => { if (!dirty) setClientId(c.client_id); }, [c.client_id, dirty]);
+
+  const submit = () =>
+    save.mutate(
+      { provider: c.provider, client_id: clientId.trim(), client_secret: secret.trim() ? secret.trim() : undefined },
+      {
+        onSuccess: () => { toast(`${meta.name} credentials saved`); setSecret(""); setDirty(false); },
+        onError: (e: unknown) => toast.error((e as Error).message),
+      }
+    );
+
+  return (
+    <div className="px-2 py-3 border-b border-border last:border-b-0">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-sm font-medium">{meta.name}</span>
+        {c.configured ? <Badge variant="secondary">Connected</Badge> : <Badge variant="outline">Not set</Badge>}
+        {managed ? <Badge variant="outline">Worker secret</Badge> : null}
+      </div>
+      {managed ? (
+        <div className="text-[13px] text-muted-foreground">
+          Set by a Worker secret, which always wins over anything stored here. Rotate it with{" "}
+          <code className="text-[12px]">wrangler secret put</code>, or remove the secret to manage it in this form.
+        </div>
+      ) : (
+        <FieldGroup>
+          <Field>
+            <FieldLabel htmlFor={`cid-${c.provider}`}>Client ID</FieldLabel>
+            <Input id={`cid-${c.provider}`} value={clientId} autoComplete="off" onChange={(e) => { setClientId(e.target.value); setDirty(true); }} className={cn(compact && "h-11 text-[16px]")} />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor={`csec-${c.provider}`}>Client secret</FieldLabel>
+            <Input id={`csec-${c.provider}`} type="password" autoComplete="off" value={secret} onChange={(e) => { setSecret(e.target.value); setDirty(true); }} placeholder={c.secret_hint ? `Stored · ${c.secret_hint}` : "Client secret"} className={cn(compact && "h-11 text-[16px]")} />
+            <FieldDescription className="flex flex-wrap items-center gap-2">
+              <span>{meta.hint} Encrypted on your server and never shown again.</span>
+              {c.secret_hint ? (
+                <button type="button" className="underline underline-offset-2" onClick={() => save.mutate({ provider: c.provider, client_secret: null }, { onSuccess: () => toast("Secret removed") })}>Remove</button>
+              ) : null}
+            </FieldDescription>
+          </Field>
+          <div>
+            <Button size={compact ? "lg" : "sm"} disabled={save.isPending || (!dirty && !secret)} onClick={submit}>
+              {save.isPending ? <Loader2 className="animate-spin" /> : null} Save
+            </Button>
+          </div>
+        </FieldGroup>
+      )}
+    </div>
+  );
+}
+
+/** Manage the OAuth app credentials used to connect Gmail and Outlook. */
+export function ConnectorCredentialsSection({ compact }: { compact?: boolean }) {
+  const { data, isLoading } = useOAuthCredentials();
+  return (
+    <Section title="Provider credentials" description="The OAuth apps heyflare uses to connect Gmail and Outlook. Rotate a secret here without redeploying.">
+      {isLoading ? (
+        <div className="px-2 py-2"><Skeleton className="h-16 w-full" /></div>
+      ) : (
+        <div>{(data ?? []).map((c) => <CredentialRow key={c.provider} c={c} compact={compact} />)}</div>
+      )}
+    </Section>
+  );
+}
+
 export function AccountsSection({ onNewMailbox }: { onNewMailbox?: () => void }) {
   const { accounts } = useAccount();
   const [addImap, setAddImap] = useState(false);
@@ -834,6 +910,7 @@ export function AccountsSection({ onNewMailbox }: { onNewMailbox?: () => void })
           <div>{remote.map((a) => <AccountBlock key={a.id} a={a} />)}</div>
         )}
       </Section>
+      <ConnectorCredentialsSection />
       <Section
         title="Domain mailboxes"
         description="Addresses on your own domains."

--- a/src/web/pages/Settings.tsx
+++ b/src/web/pages/Settings.tsx
@@ -817,7 +817,11 @@ const PROVIDER_LABELS: Record<string, { name: string; hint: string; docs: string
 function CredentialRow({ c, compact }: { c: OAuthCredentialStatus; compact?: boolean }) {
   const { save } = useOAuthMutations();
   const meta = PROVIDER_LABELS[c.provider];
+  // A Worker secret is used by default, but you can take over here — otherwise a deployment set up
+  // with `wrangler secret put` could never rotate an expiring secret without the CLI.
   const managed = c.source === "env";
+  const [takingOver, setTakingOver] = useState(false);
+  const showForm = !managed || takingOver;
   const [clientId, setClientId] = useState(c.client_id);
   const [secret, setSecret] = useState("");
   const [dirty, setDirty] = useState(false);
@@ -827,9 +831,15 @@ function CredentialRow({ c, compact }: { c: OAuthCredentialStatus; compact?: boo
     save.mutate(
       { provider: c.provider, client_id: clientId.trim(), client_secret: secret.trim() ? secret.trim() : undefined },
       {
-        onSuccess: () => { toast(`${meta.name} credentials saved`); setSecret(""); setDirty(false); },
+        onSuccess: () => { toast(`${meta.name} credentials saved`); setSecret(""); setDirty(false); setTakingOver(false); },
         onError: (e: unknown) => toast.error((e as Error).message),
       }
+    );
+
+  const revert = () =>
+    save.mutate(
+      { provider: c.provider, override_env: false },
+      { onSuccess: () => { toast(`Using the Worker secret for ${meta.name} again`); setTakingOver(false); }, onError: (e: unknown) => toast.error((e as Error).message) }
     );
 
   return (
@@ -838,11 +848,17 @@ function CredentialRow({ c, compact }: { c: OAuthCredentialStatus; compact?: boo
         <span className="text-sm font-medium">{meta.name}</span>
         {c.configured ? <Badge variant="secondary">Connected</Badge> : <Badge variant="outline">Not set</Badge>}
         {managed ? <Badge variant="outline">Worker secret</Badge> : null}
+        {c.overriding ? <Badge variant="outline">Overriding Worker secret</Badge> : null}
       </div>
-      {managed ? (
-        <div className="text-[13px] text-muted-foreground">
-          Set by a Worker secret, which always wins over anything stored here. Rotate it with{" "}
-          <code className="text-[12px]">wrangler secret put</code>, or remove the secret to manage it in this form.
+      {managed && !takingOver ? (
+        <div className="text-[13px] text-muted-foreground space-y-2">
+          <div>
+            Currently using the <code className="text-[12px]">{c.provider === "google" ? "GOOGLE_CLIENT_SECRET" : "MS_CLIENT_SECRET"}</code>{" "}
+            Worker secret. Rotate it with <code className="text-[12px]">wrangler secret put</code>, or manage it here instead.
+          </div>
+          <Button size="sm" variant="outline" onClick={() => { setTakingOver(true); setClientId(c.client_id); }}>
+            Manage here instead
+          </Button>
         </div>
       ) : (
         <FieldGroup>
@@ -860,10 +876,17 @@ function CredentialRow({ c, compact }: { c: OAuthCredentialStatus; compact?: boo
               ) : null}
             </FieldDescription>
           </Field>
-          <div>
+          {managed && takingOver ? (
+            <div className="rounded-md bg-muted/60 px-3 py-2 text-[13px]">
+              Saving will use these credentials instead of the Worker secret. Enter both a client ID and a secret.
+            </div>
+          ) : null}
+          <div className="flex items-center gap-2">
             <Button size={compact ? "lg" : "sm"} disabled={save.isPending || (!dirty && !secret)} onClick={submit}>
               {save.isPending ? <Loader2 className="animate-spin" /> : null} Save
             </Button>
+            {takingOver ? <Button size={compact ? "lg" : "sm"} variant="ghost" onClick={() => { setTakingOver(false); setSecret(""); setDirty(false); }}>Cancel</Button> : null}
+            {c.overriding ? <Button size={compact ? "lg" : "sm"} variant="ghost" onClick={revert} disabled={save.isPending}>Use the Worker secret</Button> : null}
           </div>
         </FieldGroup>
       )}

--- a/src/web/pages/Settings.tsx
+++ b/src/web/pages/Settings.tsx
@@ -909,7 +909,7 @@ export function ConnectorCredentialsSection({ compact }: { compact?: boolean }) 
 }
 
 export function AccountsSection({ onNewMailbox }: { onNewMailbox?: () => void }) {
-  const { accounts } = useAccount();
+  const { accounts, googleConfigured, microsoftConfigured } = useAccount();
   const [addImap, setAddImap] = useState(false);
   const remote = accounts.filter((a) => a.provider !== "domain");
   const boxes = accounts.filter((a) => a.provider === "domain");
@@ -921,12 +921,23 @@ export function AccountsSection({ onNewMailbox }: { onNewMailbox?: () => void })
         description="What's connected, and how it signs off."
         actions={
           <div className="flex items-center gap-1">
-            <Button size="sm" variant="ghost" className="text-muted-foreground" asChild><a href="/auth/google/start"><Plus /> Connect Gmail</a></Button>
-            <Button size="sm" variant="ghost" className="text-muted-foreground" asChild><a href="/auth/microsoft/start"><Plus /> Connect Outlook</a></Button>
+            {googleConfigured ? (
+              <Button size="sm" variant="ghost" className="text-muted-foreground" asChild><a href="/auth/google/start"><Plus /> Connect Gmail</a></Button>
+            ) : null}
+            {microsoftConfigured ? (
+              <Button size="sm" variant="ghost" className="text-muted-foreground" asChild><a href="/auth/microsoft/start"><Plus /> Connect Outlook</a></Button>
+            ) : null}
             <Button size="sm" variant="ghost" className="text-muted-foreground" onClick={() => setAddImap(true)}><Plus /> Add mailbox</Button>
           </div>
         }
       >
+        {!googleConfigured || !microsoftConfigured ? (
+          <div className="mx-2 mb-3 rounded-md bg-muted/60 px-3 py-2 text-[13px] text-muted-foreground">
+            {!googleConfigured && !microsoftConfigured ? "Gmail and Outlook need" : !googleConfigured ? "Gmail needs" : "Outlook needs"} an OAuth
+            client before {!googleConfigured && !microsoftConfigured ? "they" : "it"} can be connected — add the credentials under{" "}
+            <strong>Provider credentials</strong> below. IMAP mailboxes need no setup.
+          </div>
+        ) : null}
         {remote.length === 0 ? (
           <div className="px-2 py-2 text-[13px] text-muted-foreground">Nothing connected yet.</div>
         ) : (

--- a/src/web/pages/Settings.tsx
+++ b/src/web/pages/Settings.tsx
@@ -702,8 +702,9 @@ export function EditImapDialog({ account, open, onOpenChange, variant = "dialog"
   const close = () => { onOpenChange(false); setPassword(""); setLoaded(false); };
   const submit = () =>
     update.mutate(
-      { id: account.id, imap_host: imapHost.trim(), imap_port: imapPort, smtp_host: smtpHost.trim(), smtp_port: smtpPort,
-        smtp_security: smtpPort === 587 ? "starttls" : "tls", ...(password.trim() ? { password: password.trim() } : {}) },
+      { id: account.id, imap_host: imapHost.trim(), imap_port: imapPort, imap_security: imapPort === 143 ? "starttls" : "tls",
+        smtp_host: smtpHost.trim(), smtp_port: smtpPort, smtp_security: smtpPort === 587 ? "starttls" : "tls",
+        ...(password.trim() ? { password: password.trim() } : {}) },
       { onSuccess: () => { toast(`${account.email} updated`); close(); },
         onError: (e: unknown) => toast.error("Couldn't connect", { description: (e as Error).message, duration: 12000 }) }
     );
@@ -737,6 +738,7 @@ export function EditImapDialog({ account, open, onOpenChange, variant = "dialog"
             <Input id="e-imap" value={imapHost} onChange={(e) => setImapHost(e.target.value)} className={cn("flex-1", mobile && "h-11 text-[16px]")} />
             <Input aria-label="IMAP port" type="number" value={imapPort} onChange={(e) => setImapPort(Number(e.target.value))} className={cn("w-24", mobile && "h-11 text-[16px]")} />
           </div>
+          <FieldDescription>993 for implicit TLS, or 143 for STARTTLS.</FieldDescription>
         </Field>
         <Field>
           <FieldLabel htmlFor="e-smtp">SMTP server</FieldLabel>
@@ -781,6 +783,7 @@ export function AddImapDialog({ open, onOpenChange, variant = "dialog" }: { open
   const [smtpHost, setSmtpHost] = useState("smtp.zoho.com");
   const [imapPort, setImapPort] = useState(993);
   const [smtpPort, setSmtpPort] = useState(465);
+  const [imapSecurity, setImapSecurity] = useState<"tls" | "starttls">("tls");
   const [smtpSecurity, setSmtpSecurity] = useState<"tls" | "starttls">("tls");
   const [advanced, setAdvanced] = useState(false);
 
@@ -791,6 +794,7 @@ export function AddImapDialog({ open, onOpenChange, variant = "dialog" }: { open
     setSmtpHost(pr.smtp_host);
     setImapPort(993);
     setSmtpPort(465);
+    setImapSecurity("tls");
     setSmtpSecurity("tls");
   };
 
@@ -806,7 +810,7 @@ export function AddImapDialog({ open, onOpenChange, variant = "dialog" }: { open
         display_name: name.trim(),
         imap_host: imapHost.trim(),
         imap_port: imapPort,
-        imap_security: "tls",
+        imap_security: imapSecurity,
         smtp_host: smtpHost.trim(),
         smtp_port: smtpPort,
         smtp_security: smtpSecurity,
@@ -875,9 +879,9 @@ export function AddImapDialog({ open, onOpenChange, variant = "dialog" }: { open
                 <FieldLabel htmlFor="imap-host">IMAP server</FieldLabel>
                 <div className="flex gap-2">
                   <Input id="imap-host" value={imapHost} onChange={(e) => setImapHost(e.target.value)} placeholder="imap.example.com" className={cn("flex-1", mobile && "h-11 text-[16px]")} />
-                  <Input aria-label="IMAP port" type="number" value={imapPort} onChange={(e) => setImapPort(Number(e.target.value))} className={cn("w-24", mobile && "h-11 text-[16px]")} />
+                  <Input aria-label="IMAP port" type="number" value={imapPort} onChange={(e) => { const v = Number(e.target.value); setImapPort(v); setImapSecurity(v === 143 ? "starttls" : "tls"); }} className={cn("w-24", mobile && "h-11 text-[16px]")} />
                 </div>
-                <FieldDescription>993 with implicit TLS.</FieldDescription>
+                <FieldDescription>993 for implicit TLS, or 143 for STARTTLS.</FieldDescription>
               </Field>
               <Field>
                 <FieldLabel htmlFor="smtp-host">SMTP server</FieldLabel>

--- a/src/web/pages/Thread.tsx
+++ b/src/web/pages/Thread.tsx
@@ -691,7 +691,7 @@ export default function Thread() {
         <AlertDialogContent size="sm">
           <AlertDialogHeader>
             <AlertDialogTitle>Delete this thread forever?</AlertDialogTitle>
-            <AlertDialogDescription>It'll be removed here and trashed in {account?.provider === "domain" ? "your mailbox" : account?.provider === "outlook" ? "Outlook" : "Gmail"}. There's no undo.</AlertDialogDescription>
+            <AlertDialogDescription>It'll be removed here and trashed in {account?.provider === "domain" || account?.provider === "imap" ? "your mailbox" : account?.provider === "outlook" ? "Outlook" : "Gmail"}. There's no undo.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>

--- a/src/web/pages/Thread.tsx
+++ b/src/web/pages/Thread.tsx
@@ -691,7 +691,7 @@ export default function Thread() {
         <AlertDialogContent size="sm">
           <AlertDialogHeader>
             <AlertDialogTitle>Delete this thread forever?</AlertDialogTitle>
-            <AlertDialogDescription>It'll be removed here and trashed in {account?.provider === "domain" ? "your mailbox" : "Gmail"}. There's no undo.</AlertDialogDescription>
+            <AlertDialogDescription>It'll be removed here and trashed in {account?.provider === "domain" ? "your mailbox" : account?.provider === "outlook" ? "Outlook" : "Gmail"}. There's no undo.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>

--- a/src/worker/ai/chat.ts
+++ b/src/worker/ai/chat.ts
@@ -20,7 +20,7 @@ export interface ChatDeps {
 
 export async function buildSystemPrompt(d: ChatDeps): Promise<string> {
   const memory = memoryText(await listMemory(d.env, d.user.id));
-  const accounts = d.accounts.map((a) => `- ${a.email} (${a.provider === "gmail" ? "Gmail" : a.provider === "outlook" ? "Outlook" : "domain mailbox"}, id ${a.id})`).join("\n") || "- none connected yet";
+  const accounts = d.accounts.map((a) => `- ${a.email} (${a.provider === "gmail" ? "Gmail" : a.provider === "outlook" ? "Outlook" : a.provider === "imap" ? "IMAP mailbox" : "domain mailbox"}, id ${a.id})`).join("\n") || "- none connected yet";
   return [
     `You are the assistant inside heyflare, a HEY-style email client. You help ${d.user.name || d.user.email} read, triage, organise, and write email.`,
     ``,

--- a/src/worker/ai/chat.ts
+++ b/src/worker/ai/chat.ts
@@ -20,7 +20,7 @@ export interface ChatDeps {
 
 export async function buildSystemPrompt(d: ChatDeps): Promise<string> {
   const memory = memoryText(await listMemory(d.env, d.user.id));
-  const accounts = d.accounts.map((a) => `- ${a.email} (${a.provider === "gmail" ? "Gmail" : "domain mailbox"}, id ${a.id})`).join("\n") || "- none connected yet";
+  const accounts = d.accounts.map((a) => `- ${a.email} (${a.provider === "gmail" ? "Gmail" : a.provider === "outlook" ? "Outlook" : "domain mailbox"}, id ${a.id})`).join("\n") || "- none connected yet";
   return [
     `You are the assistant inside heyflare, a HEY-style email client. You help ${d.user.name || d.user.email} read, triage, organise, and write email.`,
     ``,

--- a/src/worker/db.ts
+++ b/src/worker/db.ts
@@ -30,7 +30,7 @@ export interface UserRow {
 export interface AccountRow {
   id: string;
   user_id: string;
-  provider: "gmail" | "domain" | "outlook";
+  provider: "gmail" | "domain" | "outlook" | "imap";
   domain_id: string | null;
   email: string;
   display_name: string;
@@ -251,7 +251,7 @@ export function toAccount(r: AccountRow): Account {
     id: r.id,
     email: r.email,
     display_name: r.display_name,
-    provider: r.provider === "domain" ? "domain" : r.provider === "outlook" ? "outlook" : "gmail",
+    provider: r.provider === "domain" || r.provider === "outlook" || r.provider === "imap" ? r.provider : "gmail",
     domain_id: r.domain_id ?? null,
     initial_sync_done: !!r.initial_sync_done,
     initial_sync_count: r.initial_sync_count,

--- a/src/worker/db.ts
+++ b/src/worker/db.ts
@@ -30,7 +30,7 @@ export interface UserRow {
 export interface AccountRow {
   id: string;
   user_id: string;
-  provider: "gmail" | "domain";
+  provider: "gmail" | "domain" | "outlook";
   domain_id: string | null;
   email: string;
   display_name: string;
@@ -38,6 +38,8 @@ export interface AccountRow {
   refresh_token: string | null;
   token_expires_at: number | null;
   history_id: string | null;
+  /** Outlook only: the Graph @odata.deltaLink cursor. Optional — predates 0015 on older rows. */
+  delta_link?: string | null;
   initial_sync_done: number;
   initial_sync_page_token: string | null;
   initial_sync_count: number;
@@ -249,7 +251,7 @@ export function toAccount(r: AccountRow): Account {
     id: r.id,
     email: r.email,
     display_name: r.display_name,
-    provider: r.provider === "domain" ? "domain" : "gmail",
+    provider: r.provider === "domain" ? "domain" : r.provider === "outlook" ? "outlook" : "gmail",
     domain_id: r.domain_id ?? null,
     initial_sync_done: !!r.initial_sync_done,
     initial_sync_count: r.initial_sync_count,

--- a/src/worker/env.ts
+++ b/src/worker/env.ts
@@ -8,6 +8,9 @@ export interface Env {
   APP_NAME: string;
   GOOGLE_CLIENT_ID?: string;
   GOOGLE_CLIENT_SECRET?: string;
+  /** Microsoft Entra app registration (`/common` authority): Outlook.com and Microsoft 365 mailboxes. */
+  MS_CLIENT_ID?: string;
+  MS_CLIENT_SECRET?: string;
   SESSION_SECRET?: string;
   /** Cloudflare API token (Zone:Read, Email Routing Settings:Edit, Email Routing Rules:Edit) for automatic domain setup. */
   CF_API_TOKEN?: string;

--- a/src/worker/google.ts
+++ b/src/worker/google.ts
@@ -121,7 +121,7 @@ export function googleFetch(env: Env, account: AccountRow, url: string, init: Re
 }
 
 async function refreshAccessToken(env: Env, account: AccountRow): Promise<string> {
-  if (account.provider === "domain") throw new GmailError(400, "not_gmail", "Not a Gmail account");
+  if (account.provider !== "gmail") throw new GmailError(400, "not_gmail", "Not a Gmail account");
   if (!account.refresh_token) {
     await markDisconnected(env, account, "No refresh token; please reconnect the account.");
     throw new GmailError(401, "no_refresh_token", "Account disconnected: no refresh token");
@@ -167,7 +167,7 @@ export async function getAccessToken(env: Env, account: AccountRow, force = fals
 
 /** Fetch against the Gmail API. `path` is relative to users/me/ (or absolute). */
 export async function gmailFetch(env: Env, account: AccountRow, path: string, init: RequestInit = {}): Promise<Response> {
-  if (account.provider === "domain") throw new GmailError(400, "not_gmail", "Not a Gmail account");
+  if (account.provider !== "gmail") throw new GmailError(400, "not_gmail", "Not a Gmail account");
   const url = /^https?:/i.test(path) ? path : GMAIL_BASE + path;
   let token = await getAccessToken(env, account);
   const doFetch = (t: string) =>

--- a/src/worker/google.ts
+++ b/src/worker/google.ts
@@ -1,6 +1,7 @@
 import type { Env } from "./env";
 import type { AccountRow } from "./db";
 import { now } from "./db";
+import { resolveCreds } from "./oauth";
 
 const GMAIL_BASE = "https://gmail.googleapis.com/gmail/v1/users/me/";
 const BATCH_URL = "https://www.googleapis.com/batch/gmail/v1";
@@ -41,8 +42,8 @@ export class GmailError extends Error {
   }
 }
 
-export function googleConfigured(env: Env): boolean {
-  return !!(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET);
+export async function googleConfigured(env: Env): Promise<boolean> {
+  return (await resolveCreds(env, "google")).source !== "none";
 }
 
 /** True when this account's refresh token already carries the Calendar scope. */
@@ -66,9 +67,10 @@ export function hasMailScope(scopes: string | null | undefined): boolean {
  */
 export const MAIL_SCOPE_SQL = `(scopes IS NULL OR scopes = '' OR scopes LIKE '%gmail.modify%')`;
 
-export function googleAuthUrl(env: Env, state: string, redirectUri: string, loginHint?: string, mode: GoogleScopeMode = "mail"): string {
+export async function googleAuthUrl(env: Env, state: string, redirectUri: string, loginHint?: string, mode: GoogleScopeMode = "mail"): Promise<string> {
+  const { clientId } = await resolveCreds(env, "google");
   const u = new URL("https://accounts.google.com/o/oauth2/v2/auth");
-  u.searchParams.set("client_id", env.GOOGLE_CLIENT_ID!);
+  u.searchParams.set("client_id", clientId);
   u.searchParams.set("redirect_uri", redirectUri);
   u.searchParams.set("response_type", "code");
   u.searchParams.set("scope", scopesFor(mode).join(" "));
@@ -90,13 +92,14 @@ export interface TokenResponse {
 }
 
 export async function exchangeCode(env: Env, code: string, redirectUri: string): Promise<TokenResponse> {
+  const creds = await resolveCreds(env, "google");
   const res = await fetch("https://oauth2.googleapis.com/token", {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
       code,
-      client_id: env.GOOGLE_CLIENT_ID!,
-      client_secret: env.GOOGLE_CLIENT_SECRET!,
+      client_id: creds.clientId,
+      client_secret: creds.clientSecret,
       redirect_uri: redirectUri,
       grant_type: "authorization_code",
     }),
@@ -126,12 +129,13 @@ async function refreshAccessToken(env: Env, account: AccountRow): Promise<string
     await markDisconnected(env, account, "No refresh token; please reconnect the account.");
     throw new GmailError(401, "no_refresh_token", "Account disconnected: no refresh token");
   }
+  const creds = await resolveCreds(env, "google");
   const res = await fetch("https://oauth2.googleapis.com/token", {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
-      client_id: env.GOOGLE_CLIENT_ID ?? "",
-      client_secret: env.GOOGLE_CLIENT_SECRET ?? "",
+      client_id: creds.clientId,
+      client_secret: creds.clientSecret,
       refresh_token: account.refresh_token,
       grant_type: "refresh_token",
     }),

--- a/src/worker/imap.ts
+++ b/src/worker/imap.ts
@@ -21,7 +21,14 @@ export interface ImapConfig {
   password: string;
 }
 
-export class ImapError extends Error {}
+export class ImapError extends Error {
+  /** True when the server rejected the credentials, which retrying cannot fix. */
+  auth: boolean;
+  constructor(message: string, opts: { auth?: boolean } = {}) {
+    super(message);
+    this.auth = opts.auth ?? false;
+  }
+}
 
 const READ_TIMEOUT_MS = 20_000;
 
@@ -188,7 +195,18 @@ async function open(cfg: ImapConfig) {
   }
 
   const session = new ImapSession(reader, writer);
-  await session.run(`LOGIN ${quote(cfg.username)} ${quote(cfg.password)}`, "login");
+  try {
+    await session.run(`LOGIN ${quote(cfg.username)} ${quote(cfg.password)}`, "login");
+  } catch (e) {
+    // Leaving the socket open here would leak a connection on every failed poll.
+    try {
+      await socket.close();
+    } catch {
+      /* already gone */
+    }
+    if (e instanceof ImapError && /login/.test(e.message)) throw new ImapError(e.message, { auth: true });
+    throw e;
+  }
   return { socket, session };
 }
 
@@ -221,6 +239,12 @@ export async function imapFetchNew(
   const { socket, session } = await open(cfg);
   try {
     const selected = parseSelect((await session.run(`SELECT ${quote(folder)}`, "select")).map((l) => l.text));
+    // RFC 3501 requires UIDVALIDITY on SELECT. Without it every UID we store is meaningless — and
+    // since 0 is also the "never baselined" marker, accepting it would re-baseline on every run and
+    // the mailbox would stay silent forever instead of reporting a problem.
+    if (!selected.uidValidity) {
+      throw new ImapError(`imap_select_failed: ${folder} returned no UIDVALIDITY`);
+    }
     const reset = cursor.uidValidity !== 0 && selected.uidValidity !== cursor.uidValidity;
 
     // A fresh mailbox, or one that was renumbered, only records where things stand — importing the

--- a/src/worker/imap.ts
+++ b/src/worker/imap.ts
@@ -1,0 +1,257 @@
+import { connect } from "cloudflare:sockets";
+
+/**
+ * A minimal IMAP4rev1 client for Cloudflare Workers — enough to poll a folder for new mail.
+ *
+ * It reads bytes rather than text throughout: IMAP literals (`{1234}`) are counted in *octets*, and
+ * a message body is arbitrary binary, so decoding early would corrupt both the framing and the mail.
+ * Raw messages come back as bytes and go straight to postal-mime.
+ */
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+export type ImapSecurity = "tls" | "starttls";
+
+export interface ImapConfig {
+  host: string;
+  port: number;
+  security: ImapSecurity;
+  username: string;
+  password: string;
+}
+
+export class ImapError extends Error {}
+
+const READ_TIMEOUT_MS = 20_000;
+
+function timeout<T>(p: Promise<T>, ms: number, what: string): Promise<T> {
+  return Promise.race([p, new Promise<T>((_, rej) => setTimeout(() => rej(new ImapError(`imap_timeout: ${what}`)), ms))]);
+}
+
+/** A byte buffer over the socket that can hand back either a CRLF line or an exact octet count. */
+class ByteReader {
+  private buf = new Uint8Array(0);
+  constructor(private reader: ReadableStreamDefaultReader<Uint8Array>) {}
+
+  private append(chunk: Uint8Array) {
+    const next = new Uint8Array(this.buf.length + chunk.length);
+    next.set(this.buf, 0);
+    next.set(chunk, this.buf.length);
+    this.buf = next;
+  }
+
+  private async pull(what: string) {
+    const { value, done } = await timeout(this.reader.read(), READ_TIMEOUT_MS, what);
+    if (done || !value) throw new ImapError(`imap_closed: ${what}`);
+    this.append(value);
+  }
+
+  /** One CRLF-terminated line, decoded as text, without the CRLF. */
+  async line(what = "line"): Promise<string> {
+    for (;;) {
+      for (let i = 0; i + 1 < this.buf.length; i++) {
+        if (this.buf[i] === 0x0d && this.buf[i + 1] === 0x0a) {
+          const line = dec.decode(this.buf.subarray(0, i));
+          this.buf = this.buf.subarray(i + 2);
+          return line;
+        }
+      }
+      await this.pull(what);
+    }
+  }
+
+  /** Exactly `n` octets — the payload of an IMAP literal. */
+  async bytes(n: number, what = "literal"): Promise<Uint8Array> {
+    while (this.buf.length < n) await this.pull(what);
+    const out = this.buf.slice(0, n);
+    this.buf = this.buf.subarray(n);
+    return out;
+  }
+}
+
+/** A server line, with the literal that followed it (if any) already read. */
+export interface ImapLine {
+  text: string;
+  literal?: Uint8Array;
+}
+
+/** `* 1 FETCH (UID 5 BODY[] {1234}` -> 1234. Only a trailing literal counts. */
+export function literalSize(line: string): number | null {
+  const m = line.match(/\{(\d+)\}$/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+/** IMAP quoted-string: backslash and double-quote must be escaped. */
+export function quote(s: string): string {
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/** Pull UIDs out of an untagged SEARCH response. */
+export function parseSearchUids(lines: string[]): number[] {
+  const out: number[] = [];
+  for (const l of lines) {
+    const m = l.match(/^\*\s+SEARCH\b(.*)$/i);
+    if (!m) continue;
+    for (const tok of m[1].trim().split(/\s+/)) {
+      const n = parseInt(tok, 10);
+      if (Number.isFinite(n)) out.push(n);
+    }
+  }
+  return out;
+}
+
+/** UIDVALIDITY and UIDNEXT out of the untagged responses to SELECT. */
+export function parseSelect(lines: string[]): { uidValidity: number; uidNext: number; exists: number } {
+  let uidValidity = 0;
+  let uidNext = 0;
+  let exists = 0;
+  for (const l of lines) {
+    const v = l.match(/\[UIDVALIDITY\s+(\d+)\]/i);
+    if (v) uidValidity = parseInt(v[1], 10);
+    const n = l.match(/\[UIDNEXT\s+(\d+)\]/i);
+    if (n) uidNext = parseInt(n[1], 10);
+    const e = l.match(/^\*\s+(\d+)\s+EXISTS/i);
+    if (e) exists = parseInt(e[1], 10);
+  }
+  return { uidValidity, uidNext, exists };
+}
+
+/** The UID from a FETCH response line, which servers may order differently. */
+export function parseFetchUid(line: string): number | null {
+  const m = line.match(/\bUID\s+(\d+)/i);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+class ImapSession {
+  private tag = 0;
+  constructor(
+    private reader: ByteReader,
+    private writer: WritableStreamDefaultWriter<Uint8Array>
+  ) {}
+
+  /** Send a command and collect untagged lines until its tagged completion. */
+  async run(command: string, what = command.split(" ")[0]): Promise<ImapLine[]> {
+    const tag = `a${(++this.tag).toString().padStart(4, "0")}`;
+    await this.writer.write(enc.encode(`${tag} ${command}\r\n`));
+    const lines: ImapLine[] = [];
+    for (;;) {
+      const text = await this.reader.line(what);
+      const size = literalSize(text);
+      if (size !== null) {
+        const literal = await this.reader.bytes(size, what);
+        lines.push({ text, literal });
+        continue;
+      }
+      if (text.startsWith(`${tag} `)) {
+        const status = text.slice(tag.length + 1).trim();
+        if (!/^OK\b/i.test(status)) throw new ImapError(`imap_${what}_failed: ${status.slice(0, 200)}`);
+        return lines;
+      }
+      lines.push({ text });
+    }
+  }
+}
+
+export interface ImapCursor {
+  /** Resets to 0 whenever the server renumbers the folder; that invalidates every stored UID. */
+  uidValidity: number;
+  lastUid: number;
+}
+
+export interface ImapFetchResult extends ImapCursor {
+  messages: { uid: number; raw: Uint8Array }[];
+  /** True when the folder was renumbered and the caller must not treat `messages` as incremental. */
+  reset: boolean;
+}
+
+async function open(cfg: ImapConfig) {
+  let socket = connect(
+    { hostname: cfg.host, port: cfg.port },
+    { secureTransport: cfg.security === "tls" ? "on" : "starttls", allowHalfOpen: false }
+  );
+  let reader = new ByteReader(socket.readable.getReader());
+  let writer = socket.writable.getWriter();
+
+  const greeting = await reader.line("greeting");
+  if (!/^\*\s+(OK|PREAUTH)/i.test(greeting)) throw new ImapError(`imap_greeting_failed: ${greeting.slice(0, 200)}`);
+
+  if (cfg.security === "starttls") {
+    const pre = new ImapSession(reader, writer);
+    await pre.run("STARTTLS", "starttls");
+    // The pre-upgrade socket is finished; everything continues on the one startTls() returns.
+    socket.readable.cancel().catch(() => {});
+    writer.releaseLock();
+    socket = socket.startTls();
+    reader = new ByteReader(socket.readable.getReader());
+    writer = socket.writable.getWriter();
+  }
+
+  const session = new ImapSession(reader, writer);
+  await session.run(`LOGIN ${quote(cfg.username)} ${quote(cfg.password)}`, "login");
+  return { socket, session };
+}
+
+/** Connect and log in, then hang up — the "Test connection" button. */
+export async function imapVerify(cfg: ImapConfig): Promise<void> {
+  const { socket, session } = await open(cfg);
+  try {
+    await session.run("LOGOUT", "logout");
+  } finally {
+    try {
+      await socket.close();
+    } catch {
+      /* the server usually closes first after LOGOUT */
+    }
+  }
+}
+
+/**
+ * Fetch messages newer than `cursor.lastUid` from `folder`.
+ *
+ * When the server reports a different UIDVALIDITY every previously stored UID is meaningless, so the
+ * result is flagged `reset` and the caller re-baselines rather than treating the batch as new mail.
+ */
+export async function imapFetchNew(
+  cfg: ImapConfig,
+  folder: string,
+  cursor: ImapCursor,
+  max = 25
+): Promise<ImapFetchResult> {
+  const { socket, session } = await open(cfg);
+  try {
+    const selected = parseSelect((await session.run(`SELECT ${quote(folder)}`, "select")).map((l) => l.text));
+    const reset = cursor.uidValidity !== 0 && selected.uidValidity !== cursor.uidValidity;
+
+    // A fresh mailbox, or one that was renumbered, only records where things stand — importing the
+    // entire history into the Screener is never what anyone wants.
+    if (cursor.uidValidity === 0 || reset) {
+      return { uidValidity: selected.uidValidity, lastUid: Math.max(0, selected.uidNext - 1), messages: [], reset };
+    }
+
+    const from = cursor.lastUid + 1;
+    const found = parseSearchUids((await session.run(`UID SEARCH UID ${from}:*`, "search")).map((l) => l.text));
+    // `UID SEARCH n:*` always returns at least the highest UID even when nothing is that new.
+    const uids = found.filter((u) => u >= from).sort((a, b) => a - b).slice(0, max);
+    if (!uids.length) return { uidValidity: selected.uidValidity, lastUid: cursor.lastUid, messages: [], reset: false };
+
+    const messages: { uid: number; raw: Uint8Array }[] = [];
+    for (const uid of uids) {
+      // BODY.PEEK leaves \Seen alone: reading here must not mark the mail read in the real mailbox.
+      const lines = await session.run(`UID FETCH ${uid} (UID BODY.PEEK[])`, "fetch");
+      const withBody = lines.find((l) => l.literal);
+      if (!withBody?.literal) continue;
+      messages.push({ uid: parseFetchUid(withBody.text) ?? uid, raw: withBody.literal });
+    }
+
+    const lastUid = messages.length ? Math.max(...messages.map((m) => m.uid)) : cursor.lastUid;
+    await session.run("LOGOUT", "logout").catch(() => {});
+    return { uidValidity: selected.uidValidity, lastUid, messages, reset: false };
+  } finally {
+    try {
+      await socket.close();
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/src/worker/imapbox.ts
+++ b/src/worker/imapbox.ts
@@ -1,0 +1,126 @@
+import type { Env } from "./env";
+import type { AccountRow } from "./db";
+import { now, logSync } from "./db";
+import { encryptSecret, decryptSecret } from "./ai/crypto";
+import { getSessionSecret } from "./secrets";
+import { imapFetchNew, imapVerify, type ImapConfig, type ImapSecurity } from "./imap";
+import { smtpSend, smtpVerify, type SmtpConfig, type SmtpSecurity } from "./smtp";
+import { parseInbound, deliverInbound } from "./inbound";
+
+/** Bodies are fetched one at a time, so this is the real cost ceiling for a cron tick. */
+const MAX_MESSAGES_PER_RUN = 25;
+
+export interface ImapAccountRow {
+  account_id: string;
+  imap_host: string;
+  imap_port: number;
+  imap_security: ImapSecurity;
+  smtp_host: string;
+  smtp_port: number;
+  smtp_security: SmtpSecurity;
+  username: string;
+  password_enc: string;
+  password_hint: string;
+  folder: string;
+  uid_validity: number;
+  last_uid: number;
+  updated_at: number;
+}
+
+export async function loadImapRow(env: Env, accountId: string): Promise<ImapAccountRow | null> {
+  return (
+    (await env.DB.prepare(`SELECT * FROM imap_accounts WHERE account_id = ?`).bind(accountId).first<ImapAccountRow>()) ?? null
+  );
+}
+
+/** Mask a password for display. The plaintext never leaves the worker. */
+export function passwordHint(password: string): string {
+  return password.length > 4 ? `${"•".repeat(Math.min(8, password.length - 2))}${password.slice(-2)}` : "••••";
+}
+
+export async function encryptPassword(env: Env, password: string): Promise<string> {
+  return encryptSecret(await getSessionSecret(env), password);
+}
+
+async function credentials(env: Env, row: ImapAccountRow): Promise<{ imap: ImapConfig; smtp: SmtpConfig }> {
+  const password = row.password_enc ? await decryptSecret(await getSessionSecret(env), row.password_enc) : "";
+  return {
+    imap: {
+      host: row.imap_host,
+      port: row.imap_port,
+      security: row.imap_security,
+      username: row.username,
+      password,
+    },
+    smtp: {
+      host: row.smtp_host,
+      port: row.smtp_port,
+      security: row.smtp_security,
+      username: row.username,
+      password,
+    },
+  };
+}
+
+export async function configFor(env: Env, accountId: string): Promise<{ imap: ImapConfig; smtp: SmtpConfig } | null> {
+  const row = await loadImapRow(env, accountId);
+  return row ? credentials(env, row) : null;
+}
+
+/** Connect and log in to both servers — what "Test connection" runs before anything is saved. */
+export async function verifyBoth(cfg: { imap: ImapConfig; smtp: SmtpConfig }): Promise<void> {
+  await imapVerify(cfg.imap);
+  await smtpVerify(cfg.smtp);
+}
+
+/**
+ * One incremental pass over an IMAP mailbox.
+ *
+ * The cursor is (UIDVALIDITY, last UID). A server that renumbers the folder changes UIDVALIDITY,
+ * which invalidates every stored UID — that case re-baselines to the current end of the folder
+ * rather than re-importing the whole history, the same choice the Gmail and Outlook paths make.
+ */
+export async function syncImapAccount(env: Env, account: AccountRow): Promise<{ added: number }> {
+  const db = env.DB;
+  const row = await loadImapRow(env, account.id);
+  if (!row) return { added: 0 };
+  const cfg = await credentials(env, row);
+
+  const result = await imapFetchNew(
+    cfg.imap,
+    row.folder,
+    { uidValidity: row.uid_validity, lastUid: row.last_uid },
+    MAX_MESSAGES_PER_RUN
+  );
+
+  if (result.reset) {
+    await logSync(db, account.id, "warn", `IMAP folder was renumbered (UIDVALIDITY changed); re-syncing from now`);
+  }
+
+  let added = 0;
+  for (const msg of result.messages) {
+    const parsed = await parseInbound(msg.raw.buffer as ArrayBuffer, "", account.email);
+    const r = await deliverInbound(env, account, parsed);
+    added += r.added;
+  }
+
+  // Only now, with every message safely ingested, does the cursor move. A throw above leaves it
+  // where it was and the next tick replays — which is safe, because ingest is idempotent.
+  await db
+    .prepare(`UPDATE imap_accounts SET uid_validity = ?, last_uid = ?, updated_at = ? WHERE account_id = ?`)
+    .bind(result.uidValidity, result.lastUid, now(), account.id)
+    .run();
+  await db.prepare(`UPDATE accounts SET initial_sync_done = 1, last_synced_at = ? WHERE id = ?`).bind(now(), account.id).run();
+  return { added };
+}
+
+/** Hand a finished RFC822 message to the mailbox's own SMTP server. */
+export async function sendViaImapAccount(
+  env: Env,
+  account: AccountRow,
+  msg: { from: string; recipients: string[]; raw: string }
+): Promise<void> {
+  const cfg = await configFor(env, account.id);
+  if (!cfg) throw new Error("smtp_not_configured");
+  await smtpSend(cfg.smtp, msg);
+}

--- a/src/worker/imapbox.ts
+++ b/src/worker/imapbox.ts
@@ -33,9 +33,15 @@ export async function loadImapRow(env: Env, accountId: string): Promise<ImapAcco
   );
 }
 
-/** Mask a password for display. The plaintext never leaves the worker. */
-export function passwordHint(password: string): string {
-  return password.length > 4 ? `${"•".repeat(Math.min(8, password.length - 2))}${password.slice(-2)}` : "••••";
+/**
+ * A fixed placeholder standing in for a stored password. Deliberately reveals nothing — not the
+ * last characters and not the length. An API key hint elsewhere in the app helps you tell two of
+ * your own keys apart; a mailbox password is a credential to someone else's system, and the ends of
+ * it are worth more to an attacker than the reassurance is worth to you.
+ */
+export const PASSWORD_PLACEHOLDER = "••••••••";
+export function passwordHint(_password: string): string {
+  return PASSWORD_PLACEHOLDER;
 }
 
 export async function encryptPassword(env: Env, password: string): Promise<string> {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -23,7 +23,7 @@ import calendarRoutes from "./routes/calendar";
 import { runCalendarSync } from "./calendar/sync";
 import { MAIL_SCOPE_SQL } from "./google";
 import { MS_MAIL_SCOPE_SQL } from "./microsoft";
-import { isConfigured } from "./oauth";
+import { configuredProviders } from "./oauth";
 import { handleInboundEmail } from "./inbound";
 import { ensureMigrations } from "./migrations";
 import { VERSION, COMMIT, BUILT_AT } from "@shared/version";
@@ -43,7 +43,8 @@ api.get("/me", async (c, next) => {
   const user = await getSessionUser(c);
   if (user) return next();
   const n = await c.env.DB.prepare(`SELECT COUNT(*) AS n FROM users`).first<{ n: number }>();
-  return c.json({ user: null, accounts: [], setup_required: (n?.n ?? 0) === 0, google_configured: await isConfigured(c.env, "google"), microsoft_configured: await isConfigured(c.env, "microsoft") });
+  const cfg = await configuredProviders(c.env);
+  return c.json({ user: null, accounts: [], setup_required: (n?.n ?? 0) === 0, google_configured: cfg.google, microsoft_configured: cfg.microsoft });
 });
 // What this deployment is running (used by the update check).
 api.get("/version", (c) => c.json({ version: VERSION, commit: COMMIT, built_at: BUILT_AT, latest: null }));

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -18,10 +18,12 @@ import bundleRoutes from "./routes/bundles";
 import aiRoutes from "./routes/ai";
 import { runLearning } from "./ai/memory";
 import domainRoutes from "./routes/domains";
+import oauthRoutes from "./routes/oauth";
 import calendarRoutes from "./routes/calendar";
 import { runCalendarSync } from "./calendar/sync";
 import { MAIL_SCOPE_SQL } from "./google";
-import { MS_MAIL_SCOPE_SQL, microsoftConfigured } from "./microsoft";
+import { MS_MAIL_SCOPE_SQL } from "./microsoft";
+import { isConfigured } from "./oauth";
 import { handleInboundEmail } from "./inbound";
 import { ensureMigrations } from "./migrations";
 import { VERSION, COMMIT, BUILT_AT } from "@shared/version";
@@ -41,7 +43,7 @@ api.get("/me", async (c, next) => {
   const user = await getSessionUser(c);
   if (user) return next();
   const n = await c.env.DB.prepare(`SELECT COUNT(*) AS n FROM users`).first<{ n: number }>();
-  return c.json({ user: null, accounts: [], setup_required: (n?.n ?? 0) === 0, google_configured: !!(c.env.GOOGLE_CLIENT_ID && c.env.GOOGLE_CLIENT_SECRET), microsoft_configured: microsoftConfigured(c.env) });
+  return c.json({ user: null, accounts: [], setup_required: (n?.n ?? 0) === 0, google_configured: await isConfigured(c.env, "google"), microsoft_configured: await isConfigured(c.env, "microsoft") });
 });
 // What this deployment is running (used by the update check).
 api.get("/version", (c) => c.json({ version: VERSION, commit: COMMIT, built_at: BUILT_AT, latest: null }));
@@ -49,6 +51,7 @@ api.use("*", requireUser);
 api.route("/me", meRoutes);
 api.route("/accounts", accountRoutes);
 api.route("/domains", domainRoutes);
+api.route("/oauth", oauthRoutes);
 api.route("/ai", aiRoutes);
 api.route("/calendar", calendarRoutes);
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -129,6 +129,22 @@ async function runCron(env: Env) {
       console.error("outlook sync failed", acc.email, e);
     }
   }
+
+  // IMAP mailboxes get their own pass too: they authenticate with a stored password, so the
+  // `refresh_token IS NOT NULL` predicate the OAuth providers rely on would exclude every one.
+  const imap = await db
+    .prepare(
+      `SELECT * FROM accounts WHERE provider = 'imap' AND sync_status <> 'disconnected' ORDER BY COALESCE(last_synced_at, 0) ASC LIMIT 8`
+    )
+    .all<AccountRow>();
+  for (const acc of imap.results) {
+    if (acc.sync_status === "syncing" && acc.last_synced_at && Date.now() - acc.last_synced_at < 10 * 60_000) continue;
+    try {
+      await syncAccount(env, acc);
+    } catch (e) {
+      console.error("imap sync failed", acc.email, e);
+    }
+  }
 }
 
 export default {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -21,6 +21,7 @@ import domainRoutes from "./routes/domains";
 import calendarRoutes from "./routes/calendar";
 import { runCalendarSync } from "./calendar/sync";
 import { MAIL_SCOPE_SQL } from "./google";
+import { MS_MAIL_SCOPE_SQL, microsoftConfigured } from "./microsoft";
 import { handleInboundEmail } from "./inbound";
 import { ensureMigrations } from "./migrations";
 import { VERSION, COMMIT, BUILT_AT } from "@shared/version";
@@ -40,7 +41,7 @@ api.get("/me", async (c, next) => {
   const user = await getSessionUser(c);
   if (user) return next();
   const n = await c.env.DB.prepare(`SELECT COUNT(*) AS n FROM users`).first<{ n: number }>();
-  return c.json({ user: null, accounts: [], setup_required: (n?.n ?? 0) === 0, google_configured: !!(c.env.GOOGLE_CLIENT_ID && c.env.GOOGLE_CLIENT_SECRET) });
+  return c.json({ user: null, accounts: [], setup_required: (n?.n ?? 0) === 0, google_configured: !!(c.env.GOOGLE_CLIENT_ID && c.env.GOOGLE_CLIENT_SECRET), microsoft_configured: microsoftConfigured(c.env) });
 });
 // What this deployment is running (used by the update check).
 api.get("/version", (c) => c.json({ version: VERSION, commit: COMMIT, built_at: BUILT_AT, latest: null }));
@@ -110,6 +111,22 @@ async function runCron(env: Env) {
       await syncAccount(env, acc);
     } catch (e) {
       console.error("sync failed", acc.email, e);
+    }
+  }
+
+  // Outlook is a separate pass rather than a widened query: MAIL_SCOPE_SQL tests for a Gmail scope,
+  // so an Outlook row could never satisfy it.
+  const outlook = await db
+    .prepare(
+      `SELECT * FROM accounts WHERE provider = 'outlook' AND sync_status <> 'disconnected' AND refresh_token IS NOT NULL AND ${MS_MAIL_SCOPE_SQL} ORDER BY COALESCE(last_synced_at, 0) ASC LIMIT 8`
+    )
+    .all<AccountRow>();
+  for (const acc of outlook.results) {
+    if (acc.sync_status === "syncing" && acc.last_synced_at && Date.now() - acc.last_synced_at < 10 * 60_000) continue;
+    try {
+      await syncAccount(env, acc);
+    } catch (e) {
+      console.error("outlook sync failed", acc.email, e);
     }
   }
 }

--- a/src/worker/microsoft.ts
+++ b/src/worker/microsoft.ts
@@ -1,0 +1,180 @@
+import type { Env } from "./env";
+import type { AccountRow } from "./db";
+import { now } from "./db";
+
+const GRAPH_BASE = "https://graph.microsoft.com/v1.0/me/";
+/**
+ * `/common` is what makes both personal Outlook.com accounts and Microsoft 365 work/school
+ * accounts sign in through the same client. `/consumers` would drop work accounts, `/organizations`
+ * would drop personal ones.
+ */
+const MS_AUTHORITY = "https://login.microsoftonline.com/common/oauth2/v2.0";
+
+/** The one scope that decides whether an account can sync mail at all. */
+export const MS_MAIL_SCOPE = "Mail.ReadWrite";
+/** Enough to identify who just signed in, plus a refresh token. */
+const MS_IDENTITY_SCOPES = ["openid", "email", "profile", "offline_access"];
+const MS_SCOPES = [MS_MAIL_SCOPE, "Mail.Send", "User.Read", ...MS_IDENTITY_SCOPES];
+
+export class MicrosoftError extends Error {
+  status: number;
+  body: string;
+  constructor(status: number, body: string, message?: string) {
+    super(message ?? `Microsoft Graph error ${status}: ${body.slice(0, 300)}`);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export function microsoftConfigured(env: Env): boolean {
+  return !!(env.MS_CLIENT_ID && env.MS_CLIENT_SECRET);
+}
+
+/**
+ * True when this account can sync mail. Microsoft echoes scopes back resource-qualified
+ * (`https://graph.microsoft.com/Mail.ReadWrite`), so this is a substring test rather than the
+ * exact-token split `hasMailScope` does for Google. An empty `scopes` counts as mail for the same
+ * reason it does there: nothing but a mail connect ever wrote an `outlook` row.
+ */
+export function hasMsMailScope(scopes: string | null | undefined): boolean {
+  const s = (scopes ?? "").trim();
+  return s === "" || s.includes(MS_MAIL_SCOPE);
+}
+
+/** The same test as `hasMsMailScope`, as a SQL predicate over an `accounts` row. Keep the two in step. */
+export const MS_MAIL_SCOPE_SQL = `(scopes IS NULL OR scopes = '' OR scopes LIKE '%Mail.ReadWrite%')`;
+
+export function msAuthUrl(env: Env, state: string, redirectUri: string, loginHint?: string): string {
+  const u = new URL(`${MS_AUTHORITY}/authorize`);
+  u.searchParams.set("client_id", env.MS_CLIENT_ID!);
+  u.searchParams.set("redirect_uri", redirectUri);
+  u.searchParams.set("response_type", "code");
+  u.searchParams.set("scope", MS_SCOPES.join(" "));
+  u.searchParams.set("response_mode", "query");
+  u.searchParams.set("state", state);
+  if (loginHint) u.searchParams.set("login_hint", loginHint);
+  return u.toString();
+}
+
+export interface MsTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  id_token?: string;
+  scope?: string;
+  token_type?: string;
+}
+
+export async function exchangeMsCode(env: Env, code: string, redirectUri: string): Promise<MsTokenResponse> {
+  const res = await fetch(`${MS_AUTHORITY}/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code,
+      client_id: env.MS_CLIENT_ID!,
+      client_secret: env.MS_CLIENT_SECRET!,
+      redirect_uri: redirectUri,
+      grant_type: "authorization_code",
+    }),
+  });
+  const body = await res.text();
+  if (!res.ok) throw new MicrosoftError(res.status, body, `Token exchange failed: ${body.slice(0, 300)}`);
+  return JSON.parse(body) as MsTokenResponse;
+}
+
+/**
+ * Who just signed in. Personal accounts often leave `mail` null and carry the address in
+ * `userPrincipalName`; work accounts populate both.
+ */
+export async function fetchMsUserInfo(accessToken: string): Promise<{ email: string; name: string }> {
+  const res = await fetch(`${GRAPH_BASE}?$select=id,mail,userPrincipalName,displayName`, {
+    headers: { authorization: `Bearer ${accessToken}` },
+  });
+  if (!res.ok) throw new MicrosoftError(res.status, await res.text(), "Graph /me failed");
+  const j = (await res.json()) as { mail?: string | null; userPrincipalName?: string; displayName?: string };
+  const email = (j.mail || j.userPrincipalName || "").toLowerCase();
+  if (!email) throw new MicrosoftError(500, JSON.stringify(j), "Graph /me returned no address");
+  return { email, name: j.displayName ?? "" };
+}
+
+async function markDisconnected(env: Env, account: AccountRow, reason: string) {
+  account.sync_status = "disconnected";
+  account.sync_error = reason;
+  await env.DB.prepare(`UPDATE accounts SET sync_status = 'disconnected', sync_error = ? WHERE id = ?`).bind(reason, account.id).run();
+}
+
+async function refreshMsAccessToken(env: Env, account: AccountRow): Promise<string> {
+  if (account.provider !== "outlook") throw new MicrosoftError(400, "not_outlook", "Not an Outlook account");
+  if (!account.refresh_token) {
+    await markDisconnected(env, account, "No refresh token; please reconnect the account.");
+    throw new MicrosoftError(401, "no_refresh_token", "Account disconnected: no refresh token");
+  }
+  const res = await fetch(`${MS_AUTHORITY}/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: env.MS_CLIENT_ID ?? "",
+      client_secret: env.MS_CLIENT_SECRET ?? "",
+      refresh_token: account.refresh_token,
+      grant_type: "refresh_token",
+      scope: MS_SCOPES.join(" "),
+    }),
+  });
+  const body = await res.text();
+  if (!res.ok) {
+    if (/invalid_grant|AADSTS700082|AADSTS50173/i.test(body)) {
+      await markDisconnected(env, account, "Microsoft revoked access. Please reconnect.");
+    }
+    throw new MicrosoftError(res.status, body, `Token refresh failed: ${body.slice(0, 200)}`);
+  }
+  const j = JSON.parse(body) as MsTokenResponse;
+  account.access_token = j.access_token;
+  account.token_expires_at = now() + (j.expires_in ?? 3600) * 1000;
+  // Unlike Google, Microsoft *rotates* refresh tokens: the old one stops working once a refresh
+  // returns a new one, so failing to persist it here would disconnect the account within the hour.
+  if (j.refresh_token) account.refresh_token = j.refresh_token;
+  await env.DB.prepare(`UPDATE accounts SET access_token = ?, refresh_token = ?, token_expires_at = ? WHERE id = ?`)
+    .bind(account.access_token, account.refresh_token, account.token_expires_at, account.id)
+    .run();
+  return j.access_token;
+}
+
+export async function getMsAccessToken(env: Env, account: AccountRow, force = false): Promise<string> {
+  if (!force && account.access_token && account.token_expires_at && account.token_expires_at - now() > 60_000) {
+    return account.access_token;
+  }
+  return refreshMsAccessToken(env, account);
+}
+
+/** Fetch against Microsoft Graph. `path` is relative to /v1.0/me/ (or absolute). */
+export async function graphFetch(env: Env, account: AccountRow, path: string, init: RequestInit = {}): Promise<Response> {
+  if (account.provider !== "outlook") throw new MicrosoftError(400, "not_outlook", "Not an Outlook account");
+  const url = /^https?:/i.test(path) ? path : GRAPH_BASE + path;
+  let token = await getMsAccessToken(env, account);
+  const doFetch = (t: string) =>
+    fetch(url, {
+      ...init,
+      headers: { ...(init.headers as Record<string, string> | undefined), authorization: `Bearer ${t}` },
+    });
+  let res = await doFetch(token);
+  if (res.status === 401) {
+    token = await getMsAccessToken(env, account, true);
+    res = await doFetch(token);
+  }
+  return res;
+}
+
+export async function graphJson<T = any>(env: Env, account: AccountRow, path: string, init: RequestInit = {}): Promise<T> {
+  const res = await graphFetch(env, account, path, init);
+  const text = await res.text();
+  if (!res.ok) throw new MicrosoftError(res.status, text);
+  return (text ? JSON.parse(text) : {}) as T;
+}
+
+/** Raw body, for `messages/{id}/$value` which returns RFC822 rather than JSON. */
+export async function graphRaw(env: Env, account: AccountRow, path: string): Promise<string> {
+  const res = await graphFetch(env, account, path);
+  const text = await res.text();
+  if (!res.ok) throw new MicrosoftError(res.status, text);
+  return text;
+}

--- a/src/worker/microsoft.ts
+++ b/src/worker/microsoft.ts
@@ -1,6 +1,7 @@
 import type { Env } from "./env";
 import type { AccountRow } from "./db";
 import { now } from "./db";
+import { resolveCreds } from "./oauth";
 
 const GRAPH_BASE = "https://graph.microsoft.com/v1.0/me/";
 /**
@@ -26,8 +27,8 @@ export class MicrosoftError extends Error {
   }
 }
 
-export function microsoftConfigured(env: Env): boolean {
-  return !!(env.MS_CLIENT_ID && env.MS_CLIENT_SECRET);
+export async function microsoftConfigured(env: Env): Promise<boolean> {
+  return (await resolveCreds(env, "microsoft")).source !== "none";
 }
 
 /**
@@ -44,9 +45,10 @@ export function hasMsMailScope(scopes: string | null | undefined): boolean {
 /** The same test as `hasMsMailScope`, as a SQL predicate over an `accounts` row. Keep the two in step. */
 export const MS_MAIL_SCOPE_SQL = `(scopes IS NULL OR scopes = '' OR scopes LIKE '%Mail.ReadWrite%')`;
 
-export function msAuthUrl(env: Env, state: string, redirectUri: string, loginHint?: string): string {
+export async function msAuthUrl(env: Env, state: string, redirectUri: string, loginHint?: string): Promise<string> {
+  const { clientId } = await resolveCreds(env, "microsoft");
   const u = new URL(`${MS_AUTHORITY}/authorize`);
-  u.searchParams.set("client_id", env.MS_CLIENT_ID!);
+  u.searchParams.set("client_id", clientId);
   u.searchParams.set("redirect_uri", redirectUri);
   u.searchParams.set("response_type", "code");
   u.searchParams.set("scope", MS_SCOPES.join(" "));
@@ -66,13 +68,14 @@ export interface MsTokenResponse {
 }
 
 export async function exchangeMsCode(env: Env, code: string, redirectUri: string): Promise<MsTokenResponse> {
+  const creds = await resolveCreds(env, "microsoft");
   const res = await fetch(`${MS_AUTHORITY}/token`, {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
       code,
-      client_id: env.MS_CLIENT_ID!,
-      client_secret: env.MS_CLIENT_SECRET!,
+      client_id: creds.clientId,
+      client_secret: creds.clientSecret,
       redirect_uri: redirectUri,
       grant_type: "authorization_code",
     }),
@@ -109,12 +112,13 @@ async function refreshMsAccessToken(env: Env, account: AccountRow): Promise<stri
     await markDisconnected(env, account, "No refresh token; please reconnect the account.");
     throw new MicrosoftError(401, "no_refresh_token", "Account disconnected: no refresh token");
   }
+  const creds = await resolveCreds(env, "microsoft");
   const res = await fetch(`${MS_AUTHORITY}/token`, {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
-      client_id: env.MS_CLIENT_ID ?? "",
-      client_secret: env.MS_CLIENT_SECRET ?? "",
+      client_id: creds.clientId,
+      client_secret: creds.clientSecret,
       refresh_token: account.refresh_token,
       grant_type: "refresh_token",
       scope: MS_SCOPES.join(" "),

--- a/src/worker/migrations.ts
+++ b/src/worker/migrations.ts
@@ -18,6 +18,7 @@ import m0013 from "../../migrations/0013_day_covers.sql";
 import m0014 from "../../migrations/0014_calendar_views.sql";
 import m0015 from "../../migrations/0015_calendar_error.sql";
 import m0016 from "../../migrations/0016_outlook.sql";
+import m0017 from "../../migrations/0017_imap.sql";
 
 export const MIGRATIONS: { name: string; sql: string }[] = [
   { name: "0001_init.sql", sql: m0001 },
@@ -36,6 +37,7 @@ export const MIGRATIONS: { name: string; sql: string }[] = [
   { name: "0014_calendar_views.sql", sql: m0014 },
   { name: "0015_calendar_error.sql", sql: m0015 },
   { name: "0016_outlook.sql", sql: m0016 },
+  { name: "0017_imap.sql", sql: m0017 },
 ];
 
 /** Split a migration file into statements: full-line comments dropped, split on `;` at end of line. */

--- a/src/worker/migrations.ts
+++ b/src/worker/migrations.ts
@@ -17,6 +17,7 @@ import m0012 from "../../migrations/0012_calendar_default_view.sql";
 import m0013 from "../../migrations/0013_day_covers.sql";
 import m0014 from "../../migrations/0014_calendar_views.sql";
 import m0015 from "../../migrations/0015_calendar_error.sql";
+import m0016 from "../../migrations/0016_outlook.sql";
 
 export const MIGRATIONS: { name: string; sql: string }[] = [
   { name: "0001_init.sql", sql: m0001 },
@@ -34,6 +35,7 @@ export const MIGRATIONS: { name: string; sql: string }[] = [
   { name: "0013_day_covers.sql", sql: m0013 },
   { name: "0014_calendar_views.sql", sql: m0014 },
   { name: "0015_calendar_error.sql", sql: m0015 },
+  { name: "0016_outlook.sql", sql: m0016 },
 ];
 
 /** Split a migration file into statements: full-line comments dropped, split on `;` at end of line. */

--- a/src/worker/migrations.ts
+++ b/src/worker/migrations.ts
@@ -19,6 +19,7 @@ import m0014 from "../../migrations/0014_calendar_views.sql";
 import m0015 from "../../migrations/0015_calendar_error.sql";
 import m0016 from "../../migrations/0016_outlook.sql";
 import m0017 from "../../migrations/0017_imap.sql";
+import m0018 from "../../migrations/0018_oauth_credentials.sql";
 
 export const MIGRATIONS: { name: string; sql: string }[] = [
   { name: "0001_init.sql", sql: m0001 },
@@ -38,6 +39,7 @@ export const MIGRATIONS: { name: string; sql: string }[] = [
   { name: "0015_calendar_error.sql", sql: m0015 },
   { name: "0016_outlook.sql", sql: m0016 },
   { name: "0017_imap.sql", sql: m0017 },
+  { name: "0018_oauth_credentials.sql", sql: m0018 },
 ];
 
 /** Split a migration file into statements: full-line comments dropped, split on `;` at end of line. */

--- a/src/worker/migrations.ts
+++ b/src/worker/migrations.ts
@@ -20,6 +20,7 @@ import m0015 from "../../migrations/0015_calendar_error.sql";
 import m0016 from "../../migrations/0016_outlook.sql";
 import m0017 from "../../migrations/0017_imap.sql";
 import m0018 from "../../migrations/0018_oauth_credentials.sql";
+import m0019 from "../../migrations/0019_oauth_override.sql";
 
 export const MIGRATIONS: { name: string; sql: string }[] = [
   { name: "0001_init.sql", sql: m0001 },
@@ -40,6 +41,7 @@ export const MIGRATIONS: { name: string; sql: string }[] = [
   { name: "0016_outlook.sql", sql: m0016 },
   { name: "0017_imap.sql", sql: m0017 },
   { name: "0018_oauth_credentials.sql", sql: m0018 },
+  { name: "0019_oauth_override.sql", sql: m0019 },
 ];
 
 /** Split a migration file into statements: full-line comments dropped, split on `;` at end of line. */

--- a/src/worker/mime.ts
+++ b/src/worker/mime.ts
@@ -286,6 +286,8 @@ export interface BuildMimeParams {
   inReplyTo?: string;
   references?: string;
   attachments?: OutgoingAttachment[];
+  /** Supply one when the caller needs to record the sent message locally; otherwise a fresh id is minted. */
+  messageId?: string;
 }
 
 function isAscii(s: string): boolean {
@@ -313,14 +315,21 @@ function randomBoundary(prefix: string): string {
   return `${prefix}_${Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("")}`;
 }
 
-export function buildRawMime(p: BuildMimeParams): string {
+/**
+ * The message as a real RFC822 string. Recipients live in the headers, Bcc included: both consumers
+ * of this — the Gmail `raw` field and Graph's MIME `sendMail` — derive the envelope from the headers
+ * and strip Bcc themselves. A direct SMTP transport would instead need Bcc omitted here and passed
+ * as envelope RCPT TO, which is what `opts.includeBcc` is for.
+ */
+export function buildRfc822(p: BuildMimeParams, opts: { includeBcc?: boolean } = {}): string {
+  const includeBcc = opts.includeBcc ?? true;
   const CRLF = "\r\n";
   const lines: string[] = [];
-  const msgId = `<${crypto.randomUUID()}@${p.from.email.split("@")[1] || "hey.local"}>`;
+  const msgId = p.messageId ?? `<${crypto.randomUUID()}@${p.from.email.split("@")[1] || "hey.local"}>`;
   lines.push(`From: ${formatAddress(p.from)}`);
   if (p.to.length) lines.push(`To: ${p.to.map(formatAddress).join(", ")}`);
   if (p.cc?.length) lines.push(`Cc: ${p.cc.map(formatAddress).join(", ")}`);
-  if (p.bcc?.length) lines.push(`Bcc: ${p.bcc.map(formatAddress).join(", ")}`);
+  if (includeBcc && p.bcc?.length) lines.push(`Bcc: ${p.bcc.map(formatAddress).join(", ")}`);
   lines.push(`Subject: ${encodeHeaderWord(p.subject ?? "")}`);
   lines.push(`Date: ${new Date().toUTCString()}`);
   lines.push(`Message-ID: ${msgId}`);
@@ -376,6 +385,15 @@ export function buildRawMime(p: BuildMimeParams): string {
     body = altBody;
   }
 
-  const raw = lines.join(CRLF) + CRLF + CRLF + body + CRLF;
-  return Buffer.from(raw, "utf8").toString("base64url");
+  return lines.join(CRLF) + CRLF + CRLF + body + CRLF;
+}
+
+/** The Gmail `messages/send` `raw` field: base64url of {@link buildRfc822}. */
+export function buildRawMime(p: BuildMimeParams): string {
+  return Buffer.from(buildRfc822(p), "utf8").toString("base64url");
+}
+
+/** Graph's `POST /me/sendMail` MIME body: standard base64 of {@link buildRfc822}. */
+export function buildMimeBase64(p: BuildMimeParams): string {
+  return Buffer.from(buildRfc822(p), "utf8").toString("base64");
 }

--- a/src/worker/oauth.ts
+++ b/src/worker/oauth.ts
@@ -1,0 +1,121 @@
+import type { Env } from "./env";
+import { now } from "./db";
+import { encryptSecret, decryptSecret } from "./ai/crypto";
+import { getSessionSecret } from "./secrets";
+
+/**
+ * Where a provider's OAuth app credentials come from.
+ *
+ * A Worker secret always wins: it lives in Cloudflare's secret store rather than the database, so it
+ * is the stronger place to keep one and an existing deploy must never change behaviour. The stored
+ * fallback exists because Microsoft client secrets expire — rotating one should not require CLI
+ * access and a redeploy. This mirrors `getSessionSecret`, which prefers the env var and otherwise
+ * falls back to a value in the database.
+ */
+export type OAuthProvider = "google" | "microsoft";
+export type CredentialSource = "env" | "db" | "none";
+
+export interface ResolvedCreds {
+  clientId: string;
+  clientSecret: string;
+  source: CredentialSource;
+}
+
+interface CredRow {
+  provider: string;
+  client_id: string;
+  secret_enc: string;
+  secret_hint: string;
+  updated_at: number;
+}
+
+function envNames(provider: OAuthProvider): { id: keyof Env; secret: keyof Env } {
+  return provider === "google"
+    ? { id: "GOOGLE_CLIENT_ID", secret: "GOOGLE_CLIENT_SECRET" }
+    : { id: "MS_CLIENT_ID", secret: "MS_CLIENT_SECRET" };
+}
+
+export async function resolveCreds(env: Env, provider: OAuthProvider): Promise<ResolvedCreds> {
+  const names = envNames(provider);
+  const envId = (env[names.id] as string | undefined) ?? "";
+  const envSecret = (env[names.secret] as string | undefined) ?? "";
+  if (envId && envSecret) return { clientId: envId, clientSecret: envSecret, source: "env" };
+
+  const row = await env.DB.prepare(`SELECT * FROM oauth_credentials WHERE provider = ?`).bind(provider).first<CredRow>();
+  if (!row?.client_id || !row?.secret_enc) return { clientId: "", clientSecret: "", source: "none" };
+  try {
+    const secret = await decryptSecret(await getSessionSecret(env), row.secret_enc);
+    return { clientId: row.client_id, clientSecret: secret, source: "db" };
+  } catch {
+    // A SESSION_SECRET that changed leaves the ciphertext unreadable; treat it as unconfigured
+    // rather than throwing on every request.
+    return { clientId: "", clientSecret: "", source: "none" };
+  }
+}
+
+export async function isConfigured(env: Env, provider: OAuthProvider): Promise<boolean> {
+  return (await resolveCreds(env, provider)).source !== "none";
+}
+
+/** Mask a secret for display; the plaintext is never returned by the API. */
+export function secretHint(secret: string): string {
+  return secret.length > 8 ? `${secret.slice(0, 3)}…${secret.slice(-3)}` : "••••";
+}
+
+export interface CredentialStatus {
+  provider: OAuthProvider;
+  configured: boolean;
+  /** "env" means a Worker secret is set, so the stored value is ignored and the UI is read-only. */
+  source: CredentialSource;
+  client_id: string;
+  secret_hint: string;
+}
+
+export async function credentialsStatus(env: Env, provider: OAuthProvider): Promise<CredentialStatus> {
+  const resolved = await resolveCreds(env, provider);
+  const row = await env.DB.prepare(`SELECT * FROM oauth_credentials WHERE provider = ?`).bind(provider).first<CredRow>();
+  return {
+    provider,
+    configured: resolved.source !== "none",
+    source: resolved.source,
+    client_id: resolved.source === "env" ? resolved.clientId : (row?.client_id ?? ""),
+    secret_hint: resolved.source === "env" ? "set by a Worker secret" : (row?.secret_hint ?? ""),
+  };
+}
+
+/**
+ * Write the stored credentials. Three-state, matching how AI keys are saved: a string sets the
+ * value, `null` clears it, and `undefined` leaves whatever is there alone — so saving a client id
+ * does not require re-entering the secret.
+ */
+export async function saveCreds(
+  env: Env,
+  provider: OAuthProvider,
+  patch: { client_id?: string; client_secret?: string | null }
+): Promise<void> {
+  const row = await env.DB.prepare(`SELECT * FROM oauth_credentials WHERE provider = ?`).bind(provider).first<CredRow>();
+  let clientId = row?.client_id ?? "";
+  let enc = row?.secret_enc ?? "";
+  let hint = row?.secret_hint ?? "";
+
+  if (typeof patch.client_id === "string") clientId = patch.client_id.trim();
+  if (typeof patch.client_secret === "string") {
+    const secret = patch.client_secret.trim();
+    if (secret) {
+      enc = await encryptSecret(await getSessionSecret(env), secret);
+      hint = secretHint(secret);
+    }
+  } else if (patch.client_secret === null) {
+    enc = "";
+    hint = "";
+  }
+
+  await env.DB.prepare(
+    `INSERT INTO oauth_credentials (provider, client_id, secret_enc, secret_hint, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(provider) DO UPDATE SET client_id = excluded.client_id, secret_enc = excluded.secret_enc,
+       secret_hint = excluded.secret_hint, updated_at = excluded.updated_at`
+  )
+    .bind(provider, clientId, enc, hint, now())
+    .run();
+}

--- a/src/worker/oauth.ts
+++ b/src/worker/oauth.ts
@@ -65,6 +65,29 @@ export async function isConfigured(env: Env, provider: OAuthProvider): Promise<b
   return (await resolveCreds(env, provider)).source !== "none";
 }
 
+/**
+ * Whether each provider is usable, in a single query. `/api/me` reports both on every call —
+ * including the unauthenticated one the login screen makes — so asking per provider doubles the
+ * reads on the app's most-hit endpoint for no benefit.
+ */
+export async function configuredProviders(env: Env): Promise<{ google: boolean; microsoft: boolean }> {
+  const envReady = (p: OAuthProvider) => {
+    const n = envNames(p);
+    return !!((env[n.id] as string | undefined) && (env[n.secret] as string | undefined));
+  };
+  const out = { google: envReady("google"), microsoft: envReady("microsoft") };
+  if (out.google && out.microsoft) return out;
+
+  const rows = await env.DB.prepare(
+    `SELECT provider, client_id, secret_enc, override_env FROM oauth_credentials WHERE provider IN ('google', 'microsoft')`
+  ).all<Pick<CredRow, "provider" | "client_id" | "secret_enc" | "override_env">>();
+  for (const row of rows.results ?? []) {
+    const p = row.provider === "microsoft" ? "microsoft" : "google";
+    if (row.client_id && row.secret_enc) out[p] = true;
+  }
+  return out;
+}
+
 /** Mask a secret for display; the plaintext is never returned by the API. */
 export function secretHint(secret: string): string {
   return secret.length > 8 ? `${secret.slice(0, 3)}…${secret.slice(-3)}` : "••••";

--- a/src/worker/oauth.ts
+++ b/src/worker/oauth.ts
@@ -104,6 +104,13 @@ export interface CredentialStatus {
   overriding: boolean;
   client_id: string;
   secret_hint: string;
+  /**
+   * What is actually in the database, regardless of which source is in use. `client_id` and
+   * `secret_hint` above describe the *resolved* credentials, so under a Worker secret they say
+   * nothing about whether a stored value exists — which is exactly what deciding an override needs.
+   */
+  stored_client_id: string;
+  has_stored_secret: boolean;
 }
 
 export async function credentialsStatus(env: Env, provider: OAuthProvider): Promise<CredentialStatus> {
@@ -119,6 +126,8 @@ export async function credentialsStatus(env: Env, provider: OAuthProvider): Prom
     overriding: resolved.source === "db" && envAvailable,
     client_id: resolved.source === "env" ? resolved.clientId : (row?.client_id ?? ""),
     secret_hint: resolved.source === "env" ? "set by a Worker secret" : (row?.secret_hint ?? ""),
+    stored_client_id: row?.client_id ?? "",
+    has_stored_secret: !!row?.secret_enc,
   };
 }
 

--- a/src/worker/oauth.ts
+++ b/src/worker/oauth.ts
@@ -26,6 +26,8 @@ interface CredRow {
   client_id: string;
   secret_enc: string;
   secret_hint: string;
+  /** 1 when the stored credentials should be used even though a Worker secret exists. */
+  override_env?: number;
   updated_at: number;
 }
 
@@ -39,10 +41,16 @@ export async function resolveCreds(env: Env, provider: OAuthProvider): Promise<R
   const names = envNames(provider);
   const envId = (env[names.id] as string | undefined) ?? "";
   const envSecret = (env[names.secret] as string | undefined) ?? "";
-  if (envId && envSecret) return { clientId: envId, clientSecret: envSecret, source: "env" };
+  const hasEnv = !!(envId && envSecret);
 
   const row = await env.DB.prepare(`SELECT * FROM oauth_credentials WHERE provider = ?`).bind(provider).first<CredRow>();
-  if (!row?.client_id || !row?.secret_enc) return { clientId: "", clientSecret: "", source: "none" };
+  const stored = !!(row?.client_id && row?.secret_enc);
+
+  // The Worker secret is the default because it lives in Cloudflare's secret store rather than the
+  // database — but only until someone deliberately takes over management here, which is the only way
+  // to rotate an expiring secret without CLI access.
+  if (hasEnv && !(stored && row?.override_env)) return { clientId: envId, clientSecret: envSecret, source: "env" };
+  if (!stored) return { clientId: "", clientSecret: "", source: "none" };
   try {
     const secret = await decryptSecret(await getSessionSecret(env), row.secret_enc);
     return { clientId: row.client_id, clientSecret: secret, source: "db" };
@@ -65,19 +73,27 @@ export function secretHint(secret: string): string {
 export interface CredentialStatus {
   provider: OAuthProvider;
   configured: boolean;
-  /** "env" means a Worker secret is set, so the stored value is ignored and the UI is read-only. */
+  /** Which credentials are actually in use right now. */
   source: CredentialSource;
+  /** True when a Worker secret exists for this provider, whether or not it is the one being used. */
+  env_available: boolean;
+  /** True when the stored credentials are deliberately overriding a Worker secret. */
+  overriding: boolean;
   client_id: string;
   secret_hint: string;
 }
 
 export async function credentialsStatus(env: Env, provider: OAuthProvider): Promise<CredentialStatus> {
+  const names = envNames(provider);
+  const envAvailable = !!((env[names.id] as string | undefined) && (env[names.secret] as string | undefined));
   const resolved = await resolveCreds(env, provider);
   const row = await env.DB.prepare(`SELECT * FROM oauth_credentials WHERE provider = ?`).bind(provider).first<CredRow>();
   return {
     provider,
     configured: resolved.source !== "none",
     source: resolved.source,
+    env_available: envAvailable,
+    overriding: resolved.source === "db" && envAvailable,
     client_id: resolved.source === "env" ? resolved.clientId : (row?.client_id ?? ""),
     secret_hint: resolved.source === "env" ? "set by a Worker secret" : (row?.secret_hint ?? ""),
   };
@@ -91,12 +107,14 @@ export async function credentialsStatus(env: Env, provider: OAuthProvider): Prom
 export async function saveCreds(
   env: Env,
   provider: OAuthProvider,
-  patch: { client_id?: string; client_secret?: string | null }
+  patch: { client_id?: string; client_secret?: string | null; override_env?: boolean }
 ): Promise<void> {
   const row = await env.DB.prepare(`SELECT * FROM oauth_credentials WHERE provider = ?`).bind(provider).first<CredRow>();
   let clientId = row?.client_id ?? "";
   let enc = row?.secret_enc ?? "";
   let hint = row?.secret_hint ?? "";
+  let override = row?.override_env ?? 0;
+  if (typeof patch.override_env === "boolean") override = patch.override_env ? 1 : 0;
 
   if (typeof patch.client_id === "string") clientId = patch.client_id.trim();
   if (typeof patch.client_secret === "string") {
@@ -111,11 +129,11 @@ export async function saveCreds(
   }
 
   await env.DB.prepare(
-    `INSERT INTO oauth_credentials (provider, client_id, secret_enc, secret_hint, updated_at)
-     VALUES (?, ?, ?, ?, ?)
+    `INSERT INTO oauth_credentials (provider, client_id, secret_enc, secret_hint, override_env, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)
      ON CONFLICT(provider) DO UPDATE SET client_id = excluded.client_id, secret_enc = excluded.secret_enc,
-       secret_hint = excluded.secret_hint, updated_at = excluded.updated_at`
+       secret_hint = excluded.secret_hint, override_env = excluded.override_env, updated_at = excluded.updated_at`
   )
-    .bind(provider, clientId, enc, hint, now())
+    .bind(provider, clientId, enc, hint, override, now())
     .run();
 }

--- a/src/worker/outlook.ts
+++ b/src/worker/outlook.ts
@@ -1,0 +1,149 @@
+import type { Env } from "./env";
+import type { AccountRow } from "./db";
+import { now, logSync } from "./db";
+import { graphJson, graphRaw, MicrosoftError } from "./microsoft";
+import { parseInbound, deliverInbound } from "./inbound";
+
+/** The inbox is the only folder we track: Sent, Drafts and Junk are not mail *arriving* for you. */
+const INBOX_DELTA_PATH = `mailFolders/inbox/messages/delta?$select=id`;
+/** Bodies are fetched one HTTP request each, so this is the real cost ceiling for a cron tick. */
+const MAX_MESSAGES_PER_RUN = 25;
+/** Bounds how much of a long delta chain one invocation will walk. */
+const MAX_PAGES = 10;
+
+interface DeltaRef {
+  id?: string;
+  "@removed"?: { reason?: string };
+}
+
+export interface DeltaPage {
+  value?: DeltaRef[];
+  "@odata.nextLink"?: string;
+  "@odata.deltaLink"?: string;
+}
+
+/**
+ * The ids on one delta page that represent a message we might not have yet.
+ *
+ * Delta tracking is collection-level, so a page also carries `@removed` tombstones and entries for
+ * messages that merely changed read state. Both are dropped here: ingest is idempotent, but fetching
+ * a full MIME body for a message we already stored is pure waste.
+ */
+export function newMessageIdsFromPage(page: DeltaPage): string[] {
+  const out: string[] = [];
+  for (const item of page.value ?? []) {
+    if (item["@removed"]) continue;
+    if (typeof item.id === "string" && item.id) out.push(item.id);
+  }
+  return out;
+}
+
+/** A delta cursor Graph will no longer accept: we must start the chain again. */
+export function isExpiredCursor(e: unknown): boolean {
+  return e instanceof MicrosoftError && (e.status === 410 || /resyncRequired|syncStateNotFound/i.test(e.body));
+}
+
+export interface DeltaWalk {
+  ids: string[];
+  /**
+   * Where to resume. Graph hands back either an `@odata.nextLink` (more pages this round) or an
+   * `@odata.deltaLink` (caught up), never both, and *either* can be stored and replayed later — so
+   * one field covers both and the cursor always advances, even mid-chain.
+   */
+  cursor: string;
+  /** True once the chain reached its `@odata.deltaLink`, i.e. we are level with the mailbox. */
+  done: boolean;
+}
+
+export async function walkDelta(
+  env: Env,
+  account: AccountRow,
+  startUrl: string,
+  opts: { collect: boolean; maxIds?: number } = { collect: true }
+): Promise<DeltaWalk> {
+  const maxIds = opts.maxIds ?? MAX_MESSAGES_PER_RUN;
+  const ids: string[] = [];
+  let url = startUrl;
+  let cursor = "";
+  let done = false;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const res: DeltaPage = await graphJson(env, account, url, { headers: { prefer: "odata.maxpagesize=50" } });
+    if (opts.collect) {
+      for (const id of newMessageIdsFromPage(res)) {
+        if (!ids.includes(id)) ids.push(id);
+      }
+    }
+    const delta = res["@odata.deltaLink"];
+    if (delta) {
+      cursor = delta;
+      done = true;
+      break;
+    }
+    const next = res["@odata.nextLink"];
+    if (!next) {
+      done = true;
+      break;
+    }
+    cursor = next;
+    // Every id already collected gets ingested before the cursor is stored, so stopping here loses
+    // nothing: the next tick resumes from this very nextLink.
+    if (opts.collect && ids.length >= maxIds) break;
+  }
+  return { ids, cursor, done };
+}
+
+/**
+ * One pass over an Outlook mailbox.
+ *
+ * The first passes only walk the chain to find out where the inbox is *now*, ingesting nothing —
+ * the same "connecting imports no history" behaviour Gmail has. A large inbox takes several ticks to
+ * walk, which is why `initial_sync_done` gates it rather than a single priming call: Graph has no
+ * "give me a token for now" shortcut for mail the way it does for directory objects.
+ *
+ * Once level, each new id is fetched as raw MIME (`/$value`) and handed to the same
+ * `parseInbound` → `deliverInbound` pair that Cloudflare Email Routing uses, so threading, the
+ * Screener and bucket classification behave identically to every other kind of mailbox.
+ */
+export async function syncOutlookAccount(env: Env, account: AccountRow): Promise<{ added: number }> {
+  const db = env.DB;
+  const priming = !account.initial_sync_done;
+  const start = account.delta_link || INBOX_DELTA_PATH;
+
+  let walked: DeltaWalk;
+  try {
+    walked = await walkDelta(env, account, start, { collect: !priming });
+  } catch (e) {
+    if (!isExpiredCursor(e)) throw e;
+    // Graph forgot this cursor. Re-walk from scratch in priming mode rather than ingesting the whole
+    // mailbox as if it were new: anything that arrived during the gap is missed, which is the lesser
+    // evil against importing years of history into the Screener.
+    await logSync(db, account.id, "warn", "Outlook delta cursor expired; re-syncing from now");
+    await db.prepare(`UPDATE accounts SET delta_link = NULL, initial_sync_done = 0 WHERE id = ?`).bind(account.id).run();
+    account.delta_link = null;
+    account.initial_sync_done = 0;
+    return { added: 0 };
+  }
+
+  let added = 0;
+  if (!priming) {
+    for (const id of walked.ids) {
+      const mime = await graphRaw(env, account, `messages/${encodeURIComponent(id)}/$value`);
+      const parsed = await parseInbound(mime, "", account.email);
+      const r = await deliverInbound(env, account, parsed);
+      added += r.added;
+    }
+  }
+
+  // Only now, with every message safely ingested, does the cursor move. A throw above leaves it
+  // where it was and the next tick replays — which is safe, because ingest is idempotent.
+  if (walked.cursor) {
+    const initialDone = priming && walked.done ? 1 : account.initial_sync_done;
+    await db
+      .prepare(`UPDATE accounts SET delta_link = ?, initial_sync_done = ?, last_synced_at = ? WHERE id = ?`)
+      .bind(walked.cursor, initialDone, now(), account.id)
+      .run();
+    account.delta_link = walked.cursor;
+    account.initial_sync_done = initialDone;
+  }
+  return { added };
+}

--- a/src/worker/routes/accounts.ts
+++ b/src/worker/routes/accounts.ts
@@ -7,7 +7,7 @@ import { syncContactPhotos } from "../people";
 import { deleteAccountData } from "./domains";
 import { appOrigin, HANDOFF_PREFIX, CAL_PREFIX } from "./auth";
 import { googleConfigured, hasMailScope } from "../google";
-import { hasMsMailScope } from "../microsoft";
+import { hasMsMailScope, microsoftConfigured } from "../microsoft";
 import { configFor, verifyBoth, encryptPassword, passwordHint, loadImapRow } from "../imapbox";
 import type { ImapSecurity } from "../imap";
 import type { SmtpSecurity } from "../smtp";
@@ -114,19 +114,27 @@ accounts.get("/:id/logs", async (c) => {
 });
 
 /**
- * Mints a one-time link that starts Google's consent flow in the *system browser*. The Mac app calls
- * this (it holds the session), then opens the URL outside the webview — Google increasingly refuses
- * to sign people in inside embedded web views, and the browser has the user's Google session anyway.
+ * Mints a one-time link that starts a provider's consent flow in the *system browser*. The native
+ * apps call this (they hold the session), then open the URL outside the webview — Google refuses to
+ * sign people in inside embedded web views, and Microsoft blocks it under some Conditional Access
+ * policies, so both go the same way rather than guessing which webview will be accepted.
  */
 accounts.post("/connect-link", async (c) => {
   const user = c.get("user");
-  if (!(await googleConfigured(c.env))) return c.json({ error: "google_not_configured", message: "Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET secrets." }, 500);
-  const body = await c.req.json<{ login_hint?: string; calendar?: boolean }>().catch(() => ({}) as { login_hint?: string; calendar?: boolean });
-  const state = `${HANDOFF_PREFIX}${body.calendar ? CAL_PREFIX : ""}${uid()}`;
+  const body = await c.req
+    .json<{ login_hint?: string; calendar?: boolean; provider?: string }>()
+    .catch(() => ({}) as { login_hint?: string; calendar?: boolean; provider?: string });
+  const provider = body.provider === "microsoft" ? "microsoft" : "google";
+  if (provider === "microsoft") {
+    if (!(await microsoftConfigured(c.env))) return c.json({ error: "microsoft_not_configured", message: "Set MS_CLIENT_ID and MS_CLIENT_SECRET secrets." }, 500);
+  } else if (!(await googleConfigured(c.env))) {
+    return c.json({ error: "google_not_configured", message: "Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET secrets." }, 500);
+  }
+  const state = `${HANDOFF_PREFIX}${provider === "google" && body.calendar ? CAL_PREFIX : ""}${uid()}`;
   await c.env.DB.prepare(`INSERT INTO oauth_states (state, user_id, created_at) VALUES (?, ?, ?)`).bind(state, user.id, now()).run();
   c.executionCtx.waitUntil(c.env.DB.prepare(`DELETE FROM oauth_states WHERE created_at < ?`).bind(now() - 3600_000).run());
   const hint = (body.login_hint ?? "").trim();
-  const url = `${appOrigin(c)}/auth/google/handoff?state=${encodeURIComponent(state)}${hint ? `&login_hint=${encodeURIComponent(hint)}` : ""}`;
+  const url = `${appOrigin(c)}/auth/${provider}/handoff?state=${encodeURIComponent(state)}${hint ? `&login_hint=${encodeURIComponent(hint)}` : ""}`;
   return c.json({ url });
 });
 

--- a/src/worker/routes/accounts.ts
+++ b/src/worker/routes/accounts.ts
@@ -7,6 +7,7 @@ import { syncContactPhotos } from "../people";
 import { deleteAccountData } from "./domains";
 import { appOrigin, HANDOFF_PREFIX, CAL_PREFIX } from "./auth";
 import { googleConfigured, hasMailScope } from "../google";
+import { hasMsMailScope } from "../microsoft";
 import { uid, now } from "../db";
 
 const accounts = new Hono<AppEnv>();
@@ -39,8 +40,9 @@ accounts.delete("/:id", async (c) => {
   if (!acc) return c.json({ error: "not_found" }, 404);
   // Explicit cleanup (D1 may not have FK enforcement on for all statements).
   await deleteAccountData(c.env.DB, acc.id);
-  // Best-effort token revocation.
-  if (acc.refresh_token) {
+  // Best-effort token revocation. Google-only: Microsoft has no equivalent revoke endpoint for a
+  // delegated refresh token, and posting one to Google's would leak it to the wrong provider.
+  if (acc.provider === "gmail" && acc.refresh_token) {
     c.executionCtx.waitUntil(
       fetch(`https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(acc.refresh_token)}`, { method: "POST" }).catch(() => {})
     );
@@ -53,7 +55,8 @@ accounts.post("/:id/sync", async (c) => {
   if (!acc) return c.json({ error: "not_found" }, 404);
   if (acc.provider === "domain") return c.json({ ok: true, added: 0, status: "ok", account: toAccount(acc) });
   // Connected for calendar only: there is no mail to fetch, and that is not a failure.
-  if (!hasMailScope(acc.scopes)) return c.json({ ok: true, added: 0, status: "ok", account: toAccount(acc) });
+  const scoped = acc.provider === "outlook" ? hasMsMailScope(acc.scopes) : hasMailScope(acc.scopes);
+  if (!scoped) return c.json({ ok: true, added: 0, status: "ok", account: toAccount(acc) });
   const r = await syncAccount(c.env, acc);
   const fresh = await ownAccount(c, acc.id);
   return c.json({ ok: r.status === "ok", added: r.added, status: r.status, account: toAccount(fresh!) });
@@ -66,12 +69,13 @@ accounts.post("/:id/reset", async (c) => {
   await deleteAccountData(c.env.DB, acc.id, { keepAccount: true });
   await c.env.DB.prepare(
     `UPDATE accounts SET initial_sync_done = 0, initial_sync_count = 0, initial_sync_page_token = NULL, history_id = NULL,
-       sync_status = 'idle', sync_error = NULL, photos_synced_at = NULL WHERE id = ?`
+       delta_link = NULL, sync_status = 'idle', sync_error = NULL, photos_synced_at = NULL WHERE id = ?`
   )
     .bind(acc.id)
     .run();
   let syncError: string | null = null;
-  if (acc.provider === "gmail" && hasMailScope(acc.scopes)) {
+  const canResync = acc.provider === "gmail" ? hasMailScope(acc.scopes) : acc.provider === "outlook" && hasMsMailScope(acc.scopes);
+  if (canResync) {
     const fresh = await ownAccount(c, acc.id);
     const r = await syncAccount(c.env, fresh!);
     if (r.status !== "ok") syncError = (await ownAccount(c, acc.id))?.sync_error ?? r.status;

--- a/src/worker/routes/accounts.ts
+++ b/src/worker/routes/accounts.ts
@@ -8,6 +8,9 @@ import { deleteAccountData } from "./domains";
 import { appOrigin, HANDOFF_PREFIX, CAL_PREFIX } from "./auth";
 import { googleConfigured, hasMailScope } from "../google";
 import { hasMsMailScope } from "../microsoft";
+import { configFor, verifyBoth, encryptPassword, passwordHint, loadImapRow } from "../imapbox";
+import type { ImapSecurity } from "../imap";
+import type { SmtpSecurity } from "../smtp";
 import { uid, now } from "../db";
 
 const accounts = new Hono<AppEnv>();
@@ -55,7 +58,7 @@ accounts.post("/:id/sync", async (c) => {
   if (!acc) return c.json({ error: "not_found" }, 404);
   if (acc.provider === "domain") return c.json({ ok: true, added: 0, status: "ok", account: toAccount(acc) });
   // Connected for calendar only: there is no mail to fetch, and that is not a failure.
-  const scoped = acc.provider === "outlook" ? hasMsMailScope(acc.scopes) : hasMailScope(acc.scopes);
+  const scoped = acc.provider === "imap" ? true : acc.provider === "outlook" ? hasMsMailScope(acc.scopes) : hasMailScope(acc.scopes);
   if (!scoped) return c.json({ ok: true, added: 0, status: "ok", account: toAccount(acc) });
   const r = await syncAccount(c.env, acc);
   const fresh = await ownAccount(c, acc.id);
@@ -74,7 +77,11 @@ accounts.post("/:id/reset", async (c) => {
     .bind(acc.id)
     .run();
   let syncError: string | null = null;
-  const canResync = acc.provider === "gmail" ? hasMailScope(acc.scopes) : acc.provider === "outlook" && hasMsMailScope(acc.scopes);
+  if (acc.provider === "imap") {
+    await c.env.DB.prepare(`UPDATE imap_accounts SET uid_validity = 0, last_uid = 0 WHERE account_id = ?`).bind(acc.id).run();
+  }
+  const canResync =
+    acc.provider === "gmail" ? hasMailScope(acc.scopes) : acc.provider === "outlook" ? hasMsMailScope(acc.scopes) : acc.provider === "imap";
   if (canResync) {
     const fresh = await ownAccount(c, acc.id);
     const r = await syncAccount(c.env, fresh!);
@@ -121,6 +128,132 @@ accounts.post("/connect-link", async (c) => {
   const hint = (body.login_hint ?? "").trim();
   const url = `${appOrigin(c)}/auth/google/handoff?state=${encodeURIComponent(state)}${hint ? `&login_hint=${encodeURIComponent(hint)}` : ""}`;
   return c.json({ url });
+});
+
+// ---------- Third-party IMAP/SMTP mailboxes ----------
+
+const EMAIL_RE = /^[^@\s]+@[^@\s.]+\.[^@\s]+$/;
+
+interface ImapBody {
+  email?: string;
+  display_name?: string;
+  imap_host?: string;
+  imap_port?: number;
+  imap_security?: string;
+  smtp_host?: string;
+  smtp_port?: number;
+  smtp_security?: string;
+  username?: string;
+  password?: string | null;
+  folder?: string;
+}
+
+function sec(v: unknown, fallback: "tls" | "starttls"): ImapSecurity & SmtpSecurity {
+  return v === "starttls" || v === "tls" ? v : fallback;
+}
+
+/** Shape a request body into a config, without touching the database. */
+function readBody(b: ImapBody) {
+  const email = String(b.email ?? "").trim().toLowerCase();
+  const username = String(b.username ?? "").trim() || email;
+  return {
+    email,
+    username,
+    display_name: String(b.display_name ?? "").trim().slice(0, 100),
+    imap_host: String(b.imap_host ?? "").trim(),
+    imap_port: Number(b.imap_port ?? 993),
+    imap_security: sec(b.imap_security, "tls"),
+    smtp_host: String(b.smtp_host ?? "").trim(),
+    smtp_port: Number(b.smtp_port ?? 465),
+    smtp_security: sec(b.smtp_security, "tls"),
+    folder: String(b.folder ?? "INBOX").trim() || "INBOX",
+  };
+}
+
+/**
+ * Add a mailbox on someone else's IMAP/SMTP server. The credentials are verified against both
+ * servers *before* anything is written, so a typo never leaves a broken account behind.
+ */
+accounts.post("/imap", async (c) => {
+  const user = c.get("user");
+  const b = await c.req.json<ImapBody>().catch(() => ({}) as ImapBody);
+  const cfg = readBody(b);
+  const password = String(b.password ?? "");
+  if (!EMAIL_RE.test(cfg.email)) return c.json({ error: "invalid_email" }, 400);
+  if (!cfg.imap_host || !cfg.smtp_host) return c.json({ error: "missing_host" }, 400);
+  if (!password) return c.json({ error: "missing_password" }, 400);
+  if (cfg.smtp_port === 25) return c.json({ error: "smtp_port_25_blocked", message: "Cloudflare blocks port 25. Use 465 or 587." }, 400);
+
+  const dup = await c.env.DB.prepare(`SELECT id FROM accounts WHERE user_id = ? AND email = ?`).bind(user.id, cfg.email).first();
+  if (dup) return c.json({ error: "account_exists" }, 409);
+
+  const creds = {
+    imap: { host: cfg.imap_host, port: cfg.imap_port, security: cfg.imap_security, username: cfg.username, password },
+    smtp: { host: cfg.smtp_host, port: cfg.smtp_port, security: cfg.smtp_security, username: cfg.username, password },
+  };
+  try {
+    await verifyBoth(creds);
+  } catch (e) {
+    return c.json({ error: "connection_failed", message: (e as Error).message?.slice(0, 300) }, 400);
+  }
+
+  let enc: string;
+  try {
+    enc = await encryptPassword(c.env, password);
+  } catch (e) {
+    return c.json({ error: (e as Error).message }, 500);
+  }
+
+  const id = uid();
+  const t = now();
+  await c.env.DB.prepare(
+    `INSERT INTO accounts (id, user_id, provider, email, display_name, access_token, refresh_token, token_expires_at, scopes,
+       history_id, delta_link, initial_sync_done, initial_sync_page_token, initial_sync_count, sync_status, sync_error,
+       last_synced_at, signature, cover_art, avatar_url, created_at)
+     VALUES (?, ?, 'imap', ?, ?, NULL, NULL, NULL, '', NULL, NULL, 0, NULL, 0, 'idle', NULL, NULL, '', '', '', ?)`
+  )
+    .bind(id, user.id, cfg.email, cfg.display_name, t)
+    .run();
+  await c.env.DB.prepare(
+    `INSERT INTO imap_accounts (account_id, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security,
+       username, password_enc, password_hint, folder, uid_validity, last_uid, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, ?)`
+  )
+    .bind(id, cfg.imap_host, cfg.imap_port, cfg.imap_security, cfg.smtp_host, cfg.smtp_port, cfg.smtp_security,
+          cfg.username, enc, passwordHint(password), cfg.folder, t)
+    .run();
+
+  // The first sync only records where the folder stands; nothing historical is imported.
+  const fresh = await ownAccount(c, id);
+  if (fresh) {
+    const { syncAccount } = await import("../sync");
+    c.executionCtx.waitUntil(syncAccount(c.env, fresh));
+  }
+  return c.json({ ok: true, account: toAccount(fresh!) });
+});
+
+/** The stored settings for a mailbox, with the password reduced to a hint. */
+accounts.get("/:id/imap", async (c) => {
+  const acc = await ownAccount(c, c.req.param("id"));
+  if (!acc || acc.provider !== "imap") return c.json({ error: "not_found" }, 404);
+  const row = await loadImapRow(c.env, acc.id);
+  if (!row) return c.json({ error: "not_found" }, 404);
+  const { password_enc, ...safe } = row;
+  return c.json(safe);
+});
+
+/** Re-check the stored credentials against both servers. */
+accounts.post("/:id/imap/test", async (c) => {
+  const acc = await ownAccount(c, c.req.param("id"));
+  if (!acc || acc.provider !== "imap") return c.json({ error: "not_found" }, 404);
+  const cfg = await configFor(c.env, acc.id);
+  if (!cfg) return c.json({ error: "not_configured" }, 400);
+  try {
+    await verifyBoth(cfg);
+    return c.json({ ok: true });
+  } catch (e) {
+    return c.json({ ok: false, error: (e as Error).message?.slice(0, 300) }, 400);
+  }
 });
 
 export default accounts;

--- a/src/worker/routes/accounts.ts
+++ b/src/worker/routes/accounts.ts
@@ -160,6 +160,10 @@ function sec(v: unknown, fallback: "tls" | "starttls"): ImapSecurity & SmtpSecur
   return v === "starttls" || v === "tls" ? v : fallback;
 }
 
+function validPort(n: number): boolean {
+  return Number.isInteger(n) && n > 0 && n < 65536;
+}
+
 /** Shape a request body into a config, without touching the database. */
 function readBody(b: ImapBody) {
   const email = String(b.email ?? "").trim().toLowerCase();
@@ -190,6 +194,7 @@ accounts.post("/imap", async (c) => {
   if (!EMAIL_RE.test(cfg.email)) return c.json({ error: "invalid_email" }, 400);
   if (!cfg.imap_host || !cfg.smtp_host) return c.json({ error: "missing_host" }, 400);
   if (!password) return c.json({ error: "missing_password" }, 400);
+  if (!validPort(cfg.imap_port) || !validPort(cfg.smtp_port)) return c.json({ error: "invalid_port" }, 400);
   if (cfg.smtp_port === 25) return c.json({ error: "smtp_port_25_blocked", message: "Cloudflare blocks port 25. Use 465 or 587." }, 400);
 
   const dup = await c.env.DB.prepare(`SELECT id FROM accounts WHERE user_id = ? AND email = ?`).bind(user.id, cfg.email).first();
@@ -248,6 +253,64 @@ accounts.get("/:id/imap", async (c) => {
   if (!row) return c.json({ error: "not_found" }, 404);
   const { password_enc, ...safe } = row;
   return c.json(safe);
+});
+
+/**
+ * Update a mailbox in place. Rotating a mail password must not mean deleting the account, because
+ * `deleteAccountData` takes the synced mail with it. Omitting `password` keeps the stored one, so
+ * changing a host or port does not require re-typing the secret.
+ */
+accounts.patch("/:id/imap", async (c) => {
+  const acc = await ownAccount(c, c.req.param("id"));
+  if (!acc || acc.provider !== "imap") return c.json({ error: "not_found" }, 404);
+  const row = await loadImapRow(c.env, acc.id);
+  if (!row) return c.json({ error: "not_configured" }, 400);
+
+  const b = await c.req.json<ImapBody>().catch(() => ({}) as ImapBody);
+  const next = {
+    imap_host: typeof b.imap_host === "string" && b.imap_host.trim() ? b.imap_host.trim() : row.imap_host,
+    imap_port: typeof b.imap_port === "number" ? b.imap_port : row.imap_port,
+    imap_security: b.imap_security ? sec(b.imap_security, row.imap_security) : row.imap_security,
+    smtp_host: typeof b.smtp_host === "string" && b.smtp_host.trim() ? b.smtp_host.trim() : row.smtp_host,
+    smtp_port: typeof b.smtp_port === "number" ? b.smtp_port : row.smtp_port,
+    smtp_security: b.smtp_security ? sec(b.smtp_security, row.smtp_security) : row.smtp_security,
+    username: typeof b.username === "string" && b.username.trim() ? b.username.trim() : row.username,
+    folder: typeof b.folder === "string" && b.folder.trim() ? b.folder.trim() : row.folder,
+  };
+  if (!validPort(next.imap_port) || !validPort(next.smtp_port)) return c.json({ error: "invalid_port" }, 400);
+  if (next.smtp_port === 25) return c.json({ error: "smtp_port_25_blocked", message: "Cloudflare blocks port 25. Use 465 or 587." }, 400);
+
+  const typed = typeof b.password === "string" ? b.password : "";
+  const password = typed || (await configFor(c.env, acc.id))?.imap.password || "";
+  if (!password) return c.json({ error: "missing_password" }, 400);
+
+  // Verify before writing, so a wrong value cannot leave a working mailbox broken.
+  try {
+    await verifyBoth({
+      imap: { host: next.imap_host, port: next.imap_port, security: next.imap_security, username: next.username, password },
+      smtp: { host: next.smtp_host, port: next.smtp_port, security: next.smtp_security, username: next.username, password },
+    });
+  } catch (e) {
+    return c.json({ error: "connection_failed", message: (e as Error).message?.slice(0, 300) }, 400);
+  }
+
+  // A different folder invalidates the stored UIDs, so re-baseline rather than replaying old ones.
+  const folderChanged = next.folder !== row.folder;
+  const enc = typed ? await encryptPassword(c.env, typed) : row.password_enc;
+  await c.env.DB.prepare(
+    `UPDATE imap_accounts SET imap_host = ?, imap_port = ?, imap_security = ?, smtp_host = ?, smtp_port = ?, smtp_security = ?,
+       username = ?, password_enc = ?, password_hint = ?, folder = ?, uid_validity = ?, last_uid = ?, updated_at = ?
+     WHERE account_id = ?`
+  )
+    .bind(next.imap_host, next.imap_port, next.imap_security, next.smtp_host, next.smtp_port, next.smtp_security,
+          next.username, enc, passwordHint(password), next.folder,
+          folderChanged ? 0 : row.uid_validity, folderChanged ? 0 : row.last_uid, now(), acc.id)
+    .run();
+
+  // Working credentials retire the disconnected state the sync loop may have set.
+  await c.env.DB.prepare(`UPDATE accounts SET sync_status = 'idle', sync_error = NULL WHERE id = ?`).bind(acc.id).run();
+  const fresh = await ownAccount(c, acc.id);
+  return c.json({ ok: true, account: toAccount(fresh!) });
 });
 
 /** Re-check the stored credentials against both servers. */

--- a/src/worker/routes/accounts.ts
+++ b/src/worker/routes/accounts.ts
@@ -120,7 +120,7 @@ accounts.get("/:id/logs", async (c) => {
  */
 accounts.post("/connect-link", async (c) => {
   const user = c.get("user");
-  if (!googleConfigured(c.env)) return c.json({ error: "google_not_configured", message: "Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET secrets." }, 500);
+  if (!(await googleConfigured(c.env))) return c.json({ error: "google_not_configured", message: "Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET secrets." }, 500);
   const body = await c.req.json<{ login_hint?: string; calendar?: boolean }>().catch(() => ({}) as { login_hint?: string; calendar?: boolean });
   const state = `${HANDOFF_PREFIX}${body.calendar ? CAL_PREFIX : ""}${uid()}`;
   await c.env.DB.prepare(`INSERT INTO oauth_states (state, user_id, created_at) VALUES (?, ?, ?)`).bind(state, user.id, now()).run();

--- a/src/worker/routes/auth.ts
+++ b/src/worker/routes/auth.ts
@@ -20,7 +20,7 @@ async function userCount(db: D1Database): Promise<number> {
 // Single-owner instance: /auth/status tells the client whether first-run setup is still needed.
 auth.get("/status", async (c) => {
   const n = await userCount(c.env.DB);
-  return c.json({ setup_required: n === 0, google_configured: googleConfigured(c.env), microsoft_configured: microsoftConfigured(c.env) });
+  return c.json({ setup_required: n === 0, google_configured: await googleConfigured(c.env), microsoft_configured: await microsoftConfigured(c.env) });
 });
 
 // One-time setup: creates the sole owner. Disabled forever once a user exists.
@@ -154,7 +154,7 @@ export function statePrefixFor(mode: GoogleScopeMode): string {
 auth.get("/google/start", async (c) => {
   const user = await getSessionUser(c);
   if (!user) return c.redirect("/login?next=/settings/accounts");
-  if (!googleConfigured(c.env)) {
+  if (!(await googleConfigured(c.env))) {
     return c.json({ error: "google_not_configured", message: "Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET secrets." }, 500);
   }
   const mode: GoogleScopeMode = c.req.query("calendar_only") === "1" ? "calendar" : c.req.query("calendar") === "1" ? "mail+calendar" : "mail";
@@ -163,7 +163,7 @@ auth.get("/google/start", async (c) => {
   // Prune old states opportunistically.
   c.executionCtx.waitUntil(c.env.DB.prepare(`DELETE FROM oauth_states WHERE created_at < ?`).bind(now() - 3600_000).run());
   const hint = c.req.query("login_hint") ?? undefined;
-  return c.redirect(googleAuthUrl(c.env, state, redirectUriFor(c), hint, mode));
+  return c.redirect(await googleAuthUrl(c.env, state, redirectUriFor(c), hint, mode));
 });
 
 /** Standalone page shown in the browser tab that finished a handoff (the app is a separate window). */
@@ -190,14 +190,14 @@ p{margin:0;color:rgba(55,53,47,.65)}
  */
 auth.get("/google/handoff", async (c) => {
   const state = c.req.query("state") ?? "";
-  if (!googleConfigured(c.env)) {
+  if (!(await googleConfigured(c.env))) {
     return c.json({ error: "google_not_configured", message: "Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET secrets." }, 500);
   }
   if (!state.startsWith(HANDOFF_PREFIX)) return c.json({ error: "invalid_state" }, 400);
   const st = await c.env.DB.prepare(`SELECT state FROM oauth_states WHERE state = ? AND created_at > ?`).bind(state, now() - 3600_000).first<{ state: string }>();
   if (!st) return c.json({ error: "invalid_state" }, 400);
   const hint = c.req.query("login_hint") ?? undefined;
-  return c.redirect(googleAuthUrl(c.env, state, redirectUriFor(c), hint, scopeModeForState(state)));
+  return c.redirect(await googleAuthUrl(c.env, state, redirectUriFor(c), hint, scopeModeForState(state)));
 });
 
 auth.get("/google/callback", async (c) => {
@@ -276,14 +276,14 @@ function msRedirectUriFor(c: any): string {
 auth.get("/microsoft/start", async (c) => {
   const user = await getSessionUser(c);
   if (!user) return c.redirect("/login?next=/settings/accounts");
-  if (!microsoftConfigured(c.env)) {
+  if (!(await microsoftConfigured(c.env))) {
     return c.json({ error: "microsoft_not_configured", message: "Set MS_CLIENT_ID and MS_CLIENT_SECRET secrets." }, 500);
   }
   const state = uid();
   await c.env.DB.prepare(`INSERT INTO oauth_states (state, user_id, created_at) VALUES (?, ?, ?)`).bind(state, user.id, now()).run();
   c.executionCtx.waitUntil(c.env.DB.prepare(`DELETE FROM oauth_states WHERE created_at < ?`).bind(now() - 3600_000).run());
   const hint = c.req.query("login_hint") ?? undefined;
-  return c.redirect(msAuthUrl(c.env, state, msRedirectUriFor(c), hint));
+  return c.redirect(await msAuthUrl(c.env, state, msRedirectUriFor(c), hint));
 });
 
 auth.get("/microsoft/callback", async (c) => {

--- a/src/worker/routes/auth.ts
+++ b/src/worker/routes/auth.ts
@@ -4,6 +4,7 @@ import type { UserRow, AccountRow } from "../db";
 import { uid, now, toUser } from "../db";
 import { hashPassword, verifyPassword, createSession, destroySession, getSessionUser } from "../auth";
 import { googleAuthUrl, googleConfigured, exchangeCode, fetchUserInfo, type GoogleScopeMode } from "../google";
+import { msAuthUrl, microsoftConfigured, exchangeMsCode, fetchMsUserInfo } from "../microsoft";
 import { ensureDefaultCalendars } from "../calendar/sources";
 import { verifyTotp, matchRecoveryCode } from "../totp";
 
@@ -19,7 +20,7 @@ async function userCount(db: D1Database): Promise<number> {
 // Single-owner instance: /auth/status tells the client whether first-run setup is still needed.
 auth.get("/status", async (c) => {
   const n = await userCount(c.env.DB);
-  return c.json({ setup_required: n === 0, google_configured: googleConfigured(c.env) });
+  return c.json({ setup_required: n === 0, google_configured: googleConfigured(c.env), microsoft_configured: microsoftConfigured(c.env) });
 });
 
 // One-time setup: creates the sole owner. Disabled forever once a user exists.
@@ -259,6 +260,82 @@ auth.get("/google/callback", async (c) => {
   } catch (e) {
     const msg = ((e as Error).message ?? "oauth_failed").slice(0, 200);
     if (handoff) return c.html(handoffPage("Not connected", `${msg}. You can close this tab and try again from heyflare.`, false), 200);
+    return c.redirect(`/?connect_error=${encodeURIComponent(msg)}`);
+  }
+});
+
+// ---------- Microsoft (Outlook.com and Microsoft 365) ----------
+// Microsoft removed Basic auth for IMAP/POP/SMTP, so OAuth is the only way in. With a token in hand
+// Graph is a better fit than IMAP+XOAUTH2 anyway: plain HTTPS, and a delta cursor shaped exactly
+// like Gmail's history id.
+
+function msRedirectUriFor(c: any): string {
+  return `${appOrigin(c)}/auth/microsoft/callback`;
+}
+
+auth.get("/microsoft/start", async (c) => {
+  const user = await getSessionUser(c);
+  if (!user) return c.redirect("/login?next=/settings/accounts");
+  if (!microsoftConfigured(c.env)) {
+    return c.json({ error: "microsoft_not_configured", message: "Set MS_CLIENT_ID and MS_CLIENT_SECRET secrets." }, 500);
+  }
+  const state = uid();
+  await c.env.DB.prepare(`INSERT INTO oauth_states (state, user_id, created_at) VALUES (?, ?, ?)`).bind(state, user.id, now()).run();
+  c.executionCtx.waitUntil(c.env.DB.prepare(`DELETE FROM oauth_states WHERE created_at < ?`).bind(now() - 3600_000).run());
+  const hint = c.req.query("login_hint") ?? undefined;
+  return c.redirect(msAuthUrl(c.env, state, msRedirectUriFor(c), hint));
+});
+
+auth.get("/microsoft/callback", async (c) => {
+  const code = c.req.query("code");
+  const state = c.req.query("state");
+  const err = c.req.query("error");
+  if (err) {
+    const desc = c.req.query("error_description") ?? err;
+    return c.redirect(`/?connect_error=${encodeURIComponent(desc.slice(0, 200))}`);
+  }
+  if (!code || !state) return c.json({ error: "missing_code_or_state" }, 400);
+  const db = c.env.DB;
+  const st = await db.prepare(`SELECT * FROM oauth_states WHERE state = ? AND created_at > ?`).bind(state, now() - 3600_000).first<{ user_id: string }>();
+  if (!st) return c.json({ error: "invalid_state" }, 400);
+  await db.prepare(`DELETE FROM oauth_states WHERE state = ?`).bind(state).run();
+  const user = await db.prepare(`SELECT * FROM users WHERE id = ?`).bind(st.user_id).first<UserRow>();
+  if (!user) return c.json({ error: "unauthorized" }, 401);
+
+  try {
+    const tok = await exchangeMsCode(c.env, code, msRedirectUriFor(c));
+    const info = await fetchMsUserInfo(tok.access_token);
+    const expiresAt = now() + (tok.expires_in ?? 3600) * 1000;
+    const existing = await db.prepare(`SELECT * FROM accounts WHERE user_id = ? AND email = ?`).bind(user.id, info.email).first<AccountRow>();
+    let accountId: string;
+    if (existing) {
+      accountId = existing.id;
+      await db
+        .prepare(
+          `UPDATE accounts SET provider = 'outlook', access_token = ?, refresh_token = COALESCE(?, refresh_token), token_expires_at = ?, scopes = ?, sync_status = 'idle', sync_error = NULL, display_name = CASE WHEN display_name = '' THEN ? ELSE display_name END WHERE id = ?`
+        )
+        .bind(tok.access_token, tok.refresh_token ?? null, expiresAt, tok.scope ?? "", info.name, existing.id)
+        .run();
+    } else {
+      accountId = uid();
+      await db
+        .prepare(
+          `INSERT INTO accounts (id, user_id, provider, email, display_name, access_token, refresh_token, token_expires_at, scopes, history_id, delta_link, initial_sync_done, initial_sync_page_token, initial_sync_count, sync_status, sync_error, last_synced_at, signature, cover_art, avatar_url, created_at)
+           VALUES (?, ?, 'outlook', ?, ?, ?, ?, ?, ?, NULL, NULL, 0, NULL, 0, 'idle', NULL, NULL, '', '', '', ?)`
+        )
+        .bind(accountId, user.id, info.email, info.name, tok.access_token, tok.refresh_token ?? null, expiresAt, tok.scope ?? "", now())
+        .run();
+    }
+    // The first pass only records where the inbox is now — nothing historical is imported, matching
+    // what connecting Gmail does.
+    const account = await db.prepare(`SELECT * FROM accounts WHERE id = ?`).bind(accountId).first<AccountRow>();
+    if (account) {
+      const { syncAccount } = await import("../sync");
+      c.executionCtx.waitUntil(syncAccount(c.env, account));
+    }
+    return c.redirect(`/?connected=1&account=${accountId}`);
+  } catch (e) {
+    const msg = ((e as Error).message ?? "oauth_failed").slice(0, 200);
     return c.redirect(`/?connect_error=${encodeURIComponent(msg)}`);
   }
 });

--- a/src/worker/routes/auth.ts
+++ b/src/worker/routes/auth.ts
@@ -286,12 +286,30 @@ auth.get("/microsoft/start", async (c) => {
   return c.redirect(await msAuthUrl(c.env, state, msRedirectUriFor(c), hint));
 });
 
+/**
+ * The system-browser half of a native connect, mirroring `/google/handoff`. The app cannot send its
+ * session cookie to the browser, so it asks the server for this one-time link instead.
+ */
+auth.get("/microsoft/handoff", async (c) => {
+  const state = c.req.query("state") ?? "";
+  if (!(await microsoftConfigured(c.env))) {
+    return c.json({ error: "microsoft_not_configured", message: "Set MS_CLIENT_ID and MS_CLIENT_SECRET secrets." }, 500);
+  }
+  if (!state.startsWith(HANDOFF_PREFIX)) return c.json({ error: "invalid_state" }, 400);
+  const st = await c.env.DB.prepare(`SELECT state FROM oauth_states WHERE state = ? AND created_at > ?`).bind(state, now() - 3600_000).first<{ state: string }>();
+  if (!st) return c.json({ error: "invalid_state" }, 400);
+  const hint = c.req.query("login_hint") ?? undefined;
+  return c.redirect(await msAuthUrl(c.env, state, msRedirectUriFor(c), hint));
+});
+
 auth.get("/microsoft/callback", async (c) => {
   const code = c.req.query("code");
   const state = c.req.query("state");
   const err = c.req.query("error");
+  const handoff = (state ?? "").startsWith(HANDOFF_PREFIX);
   if (err) {
     const desc = c.req.query("error_description") ?? err;
+    if (handoff) return c.html(handoffPage("Not connected", `Microsoft reported: ${desc.slice(0, 200)}. You can close this tab and try again from heyflare.`, false), 200);
     return c.redirect(`/?connect_error=${encodeURIComponent(desc.slice(0, 200))}`);
   }
   if (!code || !state) return c.json({ error: "missing_code_or_state" }, 400);
@@ -333,9 +351,13 @@ auth.get("/microsoft/callback", async (c) => {
       const { syncAccount } = await import("../sync");
       c.executionCtx.waitUntil(syncAccount(c.env, account));
     }
+    if (handoff) {
+      return c.html(handoffPage("Connected", `${info.email} is now syncing. You can close this tab and go back to heyflare.`, true), 200);
+    }
     return c.redirect(`/?connected=1&account=${accountId}`);
   } catch (e) {
     const msg = ((e as Error).message ?? "oauth_failed").slice(0, 200);
+    if (handoff) return c.html(handoffPage("Not connected", `${msg}. You can close this tab and try again from heyflare.`, false), 200);
     return c.redirect(`/?connect_error=${encodeURIComponent(msg)}`);
   }
 });

--- a/src/worker/routes/calendar.ts
+++ b/src/worker/routes/calendar.ts
@@ -531,7 +531,7 @@ calendar.post("/sources/:id/sync", async (c) => {
  */
 calendar.post("/google/connect-link", async (c) => {
   const user = c.get("user");
-  if (!googleConfigured(c.env)) return c.json({ error: "google_not_configured", message: "Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET secrets." }, 500);
+  if (!(await googleConfigured(c.env))) return c.json({ error: "google_not_configured", message: "Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET secrets." }, 500);
   const b = await body<{ account_id: string; calendar_only: boolean }>(c);
   let hint = "";
   if (typeof b.account_id === "string" && b.account_id) {

--- a/src/worker/routes/domains.ts
+++ b/src/worker/routes/domains.ts
@@ -246,6 +246,9 @@ export async function deleteAccountData(db: D1Database, accountId: string, opts:
       ? []
       : [
           db.prepare(`UPDATE domains SET catch_all_account_id = NULL WHERE catch_all_account_id = ?`).bind(accountId),
+          // Explicit, not relying on the FK cascade: D1 does not enforce foreign keys everywhere,
+          // and leaving this row behind would strand an encrypted password.
+          db.prepare(`DELETE FROM imap_accounts WHERE account_id = ?`).bind(accountId),
           db.prepare(`DELETE FROM accounts WHERE id = ?`).bind(accountId),
         ]),
   ]);

--- a/src/worker/routes/mail.ts
+++ b/src/worker/routes/mail.ts
@@ -621,7 +621,7 @@ mail.get("/messages/:id/attachments/:attId", async (c) => {
     "cache-control": "private, max-age=3600",
     "x-content-type-options": "nosniff",
   });
-  if (acc.provider === "domain") {
+  if (acc.provider !== "gmail") {
     const blob = await db.prepare(`SELECT data FROM attachment_blobs WHERE attachment_id = ?`).bind(att.id).first<{ data: unknown }>();
     const raw = blob?.data;
     // D1 hands BLOBs back as ArrayBuffer (remote) or number[] (local); normalize.

--- a/src/worker/routes/me.ts
+++ b/src/worker/routes/me.ts
@@ -16,6 +16,7 @@ me.get("/", async (c) => {
     accounts: accounts.results.map(toAccount),
     setup_required: false,
     google_configured: !!(c.env.GOOGLE_CLIENT_ID && c.env.GOOGLE_CLIENT_SECRET),
+    microsoft_configured: !!(c.env.MS_CLIENT_ID && c.env.MS_CLIENT_SECRET),
   });
 });
 

--- a/src/worker/routes/me.ts
+++ b/src/worker/routes/me.ts
@@ -3,7 +3,7 @@ import type { AppEnv } from "../env";
 import type { AccountRow, UserRow } from "../db";
 import { now, toAccount, toUser, safeJson } from "../db";
 import { hashPassword, verifyPassword } from "../auth";
-import { isConfigured } from "../oauth";
+import { configuredProviders } from "../oauth";
 import { generateSecret, otpauthUrl, verifyTotp, generateRecoveryCodes, hashRecoveryCode, matchRecoveryCode } from "../totp";
 import type { UserSettings } from "@shared/types";
 
@@ -12,12 +12,13 @@ const me = new Hono<AppEnv>();
 me.get("/", async (c) => {
   const user = c.get("user");
   const accounts = await c.env.DB.prepare(`SELECT * FROM accounts WHERE user_id = ? ORDER BY created_at ASC`).bind(user.id).all<AccountRow>();
+  const cfg = await configuredProviders(c.env);
   return c.json({
     user: toUser(user),
     accounts: accounts.results.map(toAccount),
     setup_required: false,
-    google_configured: await isConfigured(c.env, "google"),
-    microsoft_configured: await isConfigured(c.env, "microsoft"),
+    google_configured: cfg.google,
+    microsoft_configured: cfg.microsoft,
   });
 });
 

--- a/src/worker/routes/me.ts
+++ b/src/worker/routes/me.ts
@@ -3,6 +3,7 @@ import type { AppEnv } from "../env";
 import type { AccountRow, UserRow } from "../db";
 import { now, toAccount, toUser, safeJson } from "../db";
 import { hashPassword, verifyPassword } from "../auth";
+import { isConfigured } from "../oauth";
 import { generateSecret, otpauthUrl, verifyTotp, generateRecoveryCodes, hashRecoveryCode, matchRecoveryCode } from "../totp";
 import type { UserSettings } from "@shared/types";
 
@@ -15,8 +16,8 @@ me.get("/", async (c) => {
     user: toUser(user),
     accounts: accounts.results.map(toAccount),
     setup_required: false,
-    google_configured: !!(c.env.GOOGLE_CLIENT_ID && c.env.GOOGLE_CLIENT_SECRET),
-    microsoft_configured: !!(c.env.MS_CLIENT_ID && c.env.MS_CLIENT_SECRET),
+    google_configured: await isConfigured(c.env, "google"),
+    microsoft_configured: await isConfigured(c.env, "microsoft"),
   });
 });
 

--- a/src/worker/routes/oauth.ts
+++ b/src/worker/routes/oauth.ts
@@ -1,0 +1,44 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../env";
+import { credentialsStatus, saveCreds, type OAuthProvider } from "../oauth";
+
+const oauth = new Hono<AppEnv>();
+
+const PROVIDERS: OAuthProvider[] = ["google", "microsoft"];
+
+function isProvider(v: string): v is OAuthProvider {
+  return (PROVIDERS as string[]).includes(v);
+}
+
+/** Where each provider's credentials come from, with the secret reduced to a hint. */
+oauth.get("/", async (c) => {
+  return c.json(await Promise.all(PROVIDERS.map((p) => credentialsStatus(c.env, p))));
+});
+
+oauth.put("/:provider", async (c) => {
+  const provider = c.req.param("provider");
+  if (!isProvider(provider)) return c.json({ error: "unknown_provider" }, 400);
+
+  const status = await credentialsStatus(c.env, provider);
+  // A Worker secret is the stronger place to keep one, so it always wins. Silently storing a value
+  // that will never be used would be worse than refusing it.
+  if (status.source === "env") {
+    return c.json(
+      { error: "managed_by_secret", message: "This provider is configured by a Worker secret. Remove it to manage the credentials here." },
+      409
+    );
+  }
+
+  const b = await c.req.json<{ client_id?: string; client_secret?: string | null }>().catch(() => ({}) as never);
+  if (typeof b.client_secret === "string" && b.client_secret.trim() && b.client_secret.trim().length < 8) {
+    return c.json({ error: "invalid_secret" }, 400);
+  }
+  try {
+    await saveCreds(c.env, provider, b);
+  } catch (e) {
+    return c.json({ error: (e as Error).message }, 500);
+  }
+  return c.json(await credentialsStatus(c.env, provider));
+});
+
+export default oauth;

--- a/src/worker/routes/oauth.ts
+++ b/src/worker/routes/oauth.ts
@@ -19,22 +19,33 @@ oauth.put("/:provider", async (c) => {
   const provider = c.req.param("provider");
   if (!isProvider(provider)) return c.json({ error: "unknown_provider" }, 400);
 
-  const status = await credentialsStatus(c.env, provider);
-  // A Worker secret is the stronger place to keep one, so it always wins. Silently storing a value
-  // that will never be used would be worse than refusing it.
-  if (status.source === "env") {
-    return c.json(
-      { error: "managed_by_secret", message: "This provider is configured by a Worker secret. Remove it to manage the credentials here." },
-      409
-    );
-  }
-
-  const b = await c.req.json<{ client_id?: string; client_secret?: string | null }>().catch(() => ({}) as never);
+  const b = await c.req
+    .json<{ client_id?: string; client_secret?: string | null; override_env?: boolean }>()
+    .catch(() => ({}) as never);
   if (typeof b.client_secret === "string" && b.client_secret.trim() && b.client_secret.trim().length < 8) {
     return c.json({ error: "invalid_secret" }, 400);
   }
+
+  // Taking over from a Worker secret has to be deliberate, and it has to actually be possible —
+  // otherwise a deployment configured by `wrangler secret put` could never rotate from here, which
+  // is the whole reason this form exists. Saving credentials while a Worker secret is set implies
+  // the takeover unless the caller says otherwise.
+  const status = await credentialsStatus(c.env, provider);
+  const settingCreds = typeof b.client_id === "string" || typeof b.client_secret === "string";
+  const patch = {
+    ...b,
+    override_env: typeof b.override_env === "boolean" ? b.override_env : status.env_available && settingCreds ? true : undefined,
+  };
+
+  if (patch.override_env === true) {
+    const willHaveSecret = (typeof b.client_secret === "string" && !!b.client_secret.trim()) || !!status.secret_hint;
+    const willHaveId = (typeof b.client_id === "string" && !!b.client_id.trim()) || !!status.client_id;
+    if (!willHaveSecret || !willHaveId) {
+      return c.json({ error: "incomplete_credentials", message: "Enter both a client ID and a secret before overriding the Worker secret." }, 400);
+    }
+  }
   try {
-    await saveCreds(c.env, provider, b);
+    await saveCreds(c.env, provider, patch);
   } catch (e) {
     return c.json({ error: (e as Error).message }, 500);
   }

--- a/src/worker/routes/oauth.ts
+++ b/src/worker/routes/oauth.ts
@@ -38,8 +38,11 @@ oauth.put("/:provider", async (c) => {
   };
 
   if (patch.override_env === true) {
-    const willHaveSecret = (typeof b.client_secret === "string" && !!b.client_secret.trim()) || !!status.secret_hint;
-    const willHaveId = (typeof b.client_id === "string" && !!b.client_id.trim()) || !!status.client_id;
+    // Against the stored row specifically: under a Worker secret the resolved fields are always
+    // populated, so checking those would let an override be set with nothing behind it — leaving a
+    // row that breaks the moment the Worker secret is removed.
+    const willHaveSecret = (typeof b.client_secret === "string" && !!b.client_secret.trim()) || status.has_stored_secret;
+    const willHaveId = (typeof b.client_id === "string" && !!b.client_id.trim()) || !!status.stored_client_id;
     if (!willHaveSecret || !willHaveId) {
       return c.json({ error: "incomplete_credentials", message: "Enter both a client ID and a secret before overriding the Worker secret." }, 400);
     }

--- a/src/worker/send.ts
+++ b/src/worker/send.ts
@@ -2,7 +2,7 @@ import type { Env } from "./env";
 import type { AccountRow, MessageRow, ThreadRow } from "./db";
 import { now, safeJson } from "./db";
 import { gmailJson, gmailPost } from "./google";
-import { buildRawMime, buildMimeBase64, type GmailMessage, type OutgoingAttachment } from "./mime";
+import { buildRawMime, buildMimeBase64, buildRfc822, type GmailMessage, type OutgoingAttachment } from "./mime";
 import { graphFetch, MicrosoftError } from "./microsoft";
 import { htmlToText } from "./sanitize";
 import { ingestMessages, ingestParsed } from "./sync";
@@ -50,6 +50,7 @@ export async function sendMail(env: Env, account: AccountRow, p: SendParams): Pr
   const ctx: DomainSendCtx = { thread, replyTo, subject, inReplyTo, references, from };
   if (account.provider === "domain") return sendFromDomainMailbox(env, account, p, ctx);
   if (account.provider === "outlook") return sendFromOutlook(env, account, p, ctx);
+  if (account.provider === "imap") return sendFromImapMailbox(env, account, p, ctx);
   const raw = buildRawMime({
     from,
     to: p.to,
@@ -289,6 +290,41 @@ async function sendFromOutlook(env: Env, account: AccountRow, p: SendParams, ctx
     const body = await res.text();
     throw new MicrosoftError(res.status, body, `outlook_send_failed: ${body.slice(0, 300)}`);
   }
+  return recordSentMessage(env, account, p, ctx, messageId, text);
+}
+
+// ---------- Third-party mailboxes: the provider's own SMTP server ----------
+
+/**
+ * Sending through the mailbox's own SMTP server means the provider signs DKIM for us, so
+ * deliverability is theirs rather than something this app has to solve.
+ *
+ * Unlike the API transports, SMTP takes recipients from the *envelope*: Bcc must be a RCPT TO and
+ * must not appear in the headers, or every recipient sees it.
+ */
+async function sendFromImapMailbox(env: Env, account: AccountRow, p: SendParams, ctx: DomainSendCtx): Promise<{ thread_id: string; message_id: string }> {
+  const { sendViaImapAccount } = await import("./imapbox");
+  const domain = account.email.split("@")[1] || "localhost";
+  const messageId = `<${uid()}@${domain}>`;
+  const text = htmlToText(p.body_html);
+  const raw = buildRfc822(
+    {
+      from: ctx.from,
+      to: p.to,
+      cc: p.cc ?? [],
+      bcc: p.bcc ?? [],
+      subject: ctx.subject,
+      html: p.body_html,
+      text,
+      inReplyTo: ctx.inReplyTo,
+      references: ctx.references,
+      attachments: p.attachments ?? [],
+      messageId,
+    },
+    { includeBcc: false }
+  );
+  const recipients = [...p.to, ...(p.cc ?? []), ...(p.bcc ?? [])].map((a) => a.email).filter(Boolean);
+  await sendViaImapAccount(env, account, { from: account.email, recipients, raw });
   return recordSentMessage(env, account, p, ctx, messageId, text);
 }
 

--- a/src/worker/send.ts
+++ b/src/worker/send.ts
@@ -2,7 +2,8 @@ import type { Env } from "./env";
 import type { AccountRow, MessageRow, ThreadRow } from "./db";
 import { now, safeJson } from "./db";
 import { gmailJson, gmailPost } from "./google";
-import { buildRawMime, type GmailMessage, type OutgoingAttachment } from "./mime";
+import { buildRawMime, buildMimeBase64, type GmailMessage, type OutgoingAttachment } from "./mime";
+import { graphFetch, MicrosoftError } from "./microsoft";
 import { htmlToText } from "./sanitize";
 import { ingestMessages, ingestParsed } from "./sync";
 import { uid } from "./db";
@@ -46,9 +47,9 @@ export async function sendMail(env: Env, account: AccountRow, p: SendParams): Pr
     references = [replyTo.references_header, replyTo.message_id_header].filter(Boolean).join(" ");
   }
   const from: Address = { email: account.email, name: account.display_name };
-  if (account.provider === "domain") {
-    return sendFromDomainMailbox(env, account, p, { thread, replyTo, subject, inReplyTo, references, from });
-  }
+  const ctx: DomainSendCtx = { thread, replyTo, subject, inReplyTo, references, from };
+  if (account.provider === "domain") return sendFromDomainMailbox(env, account, p, ctx);
+  if (account.provider === "outlook") return sendFromOutlook(env, account, p, ctx);
   const raw = buildRawMime({
     from,
     to: p.to,
@@ -198,7 +199,23 @@ async function sendFromDomainMailbox(env: Env, account: AccountRow, p: SendParam
     throw new Error("sending_not_configured");
   }
 
-  // Store the sent message locally so it shows up immediately.
+  return recordSentMessage(env, account, p, ctx, messageId, text);
+}
+
+/**
+ * Store a message we just handed to a transport that gives us nothing to read back (Cloudflare Email
+ * Sending, Resend, Graph `sendMail`), so it appears in the thread immediately. The Gmail path instead
+ * re-fetches the real message by id.
+ */
+async function recordSentMessage(
+  env: Env,
+  account: AccountRow,
+  p: SendParams,
+  ctx: DomainSendCtx,
+  messageId: string,
+  text: string
+): Promise<{ thread_id: string; message_id: string }> {
+  const db = env.DB;
   const t = now();
   const parsed: ParsedMessage = {
     gmailId: messageId,
@@ -236,6 +253,43 @@ async function sendFromDomainMailbox(env: Env, account: AccountRow, p: SendParam
       .run();
   }
   return { thread_id: localThreadId, message_id: row?.id ?? "" };
+}
+
+// ---------- Outlook: Microsoft Graph ----------
+
+/**
+ * Graph accepts a whole RFC822 message as base64 with `Content-Type: text/plain`, derives the
+ * envelope from the headers (Bcc included, which it strips before delivery) and files the result in
+ * Sent Items itself — the same end state Gmail sending reaches. It answers 202 with an empty body,
+ * so there is nothing to read back and we record the message locally instead.
+ */
+async function sendFromOutlook(env: Env, account: AccountRow, p: SendParams, ctx: DomainSendCtx): Promise<{ thread_id: string; message_id: string }> {
+  const domain = account.email.split("@")[1] || "outlook.com";
+  const messageId = `<${uid()}@${domain}>`;
+  const text = htmlToText(p.body_html);
+  const mime = buildMimeBase64({
+    from: ctx.from,
+    to: p.to,
+    cc: p.cc ?? [],
+    bcc: p.bcc ?? [],
+    subject: ctx.subject,
+    html: p.body_html,
+    text,
+    inReplyTo: ctx.inReplyTo,
+    references: ctx.references,
+    attachments: p.attachments ?? [],
+    messageId,
+  });
+  const res = await graphFetch(env, account, "sendMail", {
+    method: "POST",
+    headers: { "content-type": "text/plain" },
+    body: mime,
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new MicrosoftError(res.status, body, `outlook_send_failed: ${body.slice(0, 300)}`);
+  }
+  return recordSentMessage(env, account, p, ctx, messageId, text);
 }
 
 export async function processScheduledSends(env: Env): Promise<number> {

--- a/src/worker/smtp.ts
+++ b/src/worker/smtp.ts
@@ -1,0 +1,204 @@
+import { connect } from "cloudflare:sockets";
+
+/**
+ * A minimal SMTP submission client for Cloudflare Workers.
+ *
+ * Cloudflare blocks outbound port 25 outright, so this only ever speaks *submission*: 465 with
+ * implicit TLS, or 587 upgraded with STARTTLS. Both were verified against a real server before this
+ * was written; 465 is preferred because it needs no upgrade step.
+ */
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+export type SmtpSecurity = "tls" | "starttls";
+
+export interface SmtpConfig {
+  host: string;
+  port: number;
+  security: SmtpSecurity;
+  username: string;
+  password: string;
+}
+
+export interface SmtpMessage {
+  /** Envelope sender (MAIL FROM), bare address, no display name. */
+  from: string;
+  /** Every envelope recipient (RCPT TO) — To, Cc *and* Bcc. */
+  recipients: string[];
+  /** The full RFC822 message. Bcc must not appear in its headers. */
+  raw: string;
+}
+
+export class SmtpError extends Error {
+  code: number;
+  constructor(code: number, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+const READ_TIMEOUT_MS = 15_000;
+
+function timeout<T>(p: Promise<T>, ms: number, what: string): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, rej) => setTimeout(() => rej(new SmtpError(0, `smtp_timeout: ${what}`)), ms)),
+  ]);
+}
+
+/** Reads whole SMTP replies, handling the multi-line `250-foo` / `250 bar` continuation form. */
+class ReplyReader {
+  private buf = "";
+  constructor(private reader: ReadableStreamDefaultReader<Uint8Array>) {}
+
+  async read(what: string): Promise<{ code: number; text: string }> {
+    for (;;) {
+      const complete = this.buf.split("\r\n").filter(Boolean).some((l) => /^\d{3} /.test(l));
+      if (complete) break;
+      const { value, done } = await timeout(this.reader.read(), READ_TIMEOUT_MS, what);
+      if (done) throw new SmtpError(0, `smtp_closed: ${what}`);
+      this.buf += dec.decode(value, { stream: true });
+    }
+    const text = this.buf;
+    this.buf = "";
+    const final = text.split("\r\n").filter(Boolean).find((l) => /^\d{3} /.test(l))!;
+    return { code: parseInt(final.slice(0, 3), 10), text };
+  }
+}
+
+/** Lines beginning with a dot must be escaped, or the server ends the message early (RFC 5321 §4.5.2). */
+export function dotStuff(raw: string): string {
+  return raw.replace(/\r\n\./g, "\r\n..").replace(/^\./, "..");
+}
+
+/**
+ * Pick an AUTH mechanism the server actually offers. PLAIN is a single round trip and is preferred;
+ * LOGIN is the fallback that older servers advertise instead.
+ */
+export function chooseAuth(ehlo: string): "PLAIN" | "LOGIN" | null {
+  const line = ehlo.toUpperCase();
+  const m = line.match(/^\d{3}[- ]AUTH[ =](.*)$/m);
+  if (!m) return null;
+  const mechs = m[1].split(/\s+/);
+  if (mechs.includes("PLAIN")) return "PLAIN";
+  if (mechs.includes("LOGIN")) return "LOGIN";
+  return null;
+}
+
+function b64(s: string): string {
+  return btoa(String.fromCharCode(...enc.encode(s)));
+}
+
+interface Session {
+  send(line: string): Promise<void>;
+  expect(want: number, what: string): Promise<{ code: number; text: string }>;
+  writeRaw(data: string): Promise<void>;
+  close(): Promise<void>;
+}
+
+/** Open the connection, upgrade it if needed, and log in. Shared by sending and by "Test connection". */
+async function connectAndAuth(cfg: SmtpConfig): Promise<Session> {
+  if (cfg.port === 25) throw new SmtpError(0, "smtp_port_25_blocked: Cloudflare blocks outbound port 25; use 465 or 587");
+
+  let socket = connect(
+    { hostname: cfg.host, port: cfg.port },
+    { secureTransport: cfg.security === "tls" ? "on" : "starttls", allowHalfOpen: false }
+  );
+  let reader = socket.readable.getReader();
+  let writer = socket.writable.getWriter();
+  let replies = new ReplyReader(reader);
+
+  const send = async (line: string) => {
+    await writer.write(enc.encode(line + "\r\n"));
+  };
+  const expect = async (want: number, what: string) => {
+    const r = await replies.read(what);
+    if (r.code !== want) throw new SmtpError(r.code, `smtp_${what}_failed: ${r.text.trim().slice(0, 200)}`);
+    return r;
+  };
+  const close = async () => {
+    try {
+      await socket.close();
+    } catch {
+      /* the server often closes first after QUIT */
+    }
+  };
+
+  try {
+    await expect(220, "greeting");
+    await send(`EHLO heyflare`);
+    let ehlo = (await expect(250, "ehlo")).text;
+
+    if (cfg.security === "starttls") {
+      if (!/STARTTLS/i.test(ehlo)) throw new SmtpError(0, "smtp_no_starttls: server does not offer STARTTLS");
+      await send("STARTTLS");
+      await expect(220, "starttls");
+      // The pre-upgrade socket is finished once startTls() is called; everything continues on the
+      // new one, so the old locks have to be released first.
+      reader.releaseLock();
+      writer.releaseLock();
+      socket = socket.startTls();
+      reader = socket.readable.getReader();
+      writer = socket.writable.getWriter();
+      replies = new ReplyReader(reader);
+      await send(`EHLO heyflare`);
+      ehlo = (await expect(250, "ehlo_tls")).text;
+    }
+
+    const mech = chooseAuth(ehlo);
+    if (!mech) throw new SmtpError(0, "smtp_no_auth_method: server offers neither PLAIN nor LOGIN");
+    if (mech === "PLAIN") {
+      await send(`AUTH PLAIN ${b64(`\0${cfg.username}\0${cfg.password}`)}`);
+    } else {
+      await send("AUTH LOGIN");
+      await expect(334, "auth_login");
+      await send(b64(cfg.username));
+      await expect(334, "auth_user");
+      await send(b64(cfg.password));
+    }
+    await expect(235, "auth");
+  } catch (e) {
+    await close();
+    throw e;
+  }
+
+  return {
+    send,
+    expect,
+    writeRaw: async (data: string) => {
+      await writer.write(enc.encode(data));
+    },
+    close,
+  };
+}
+
+export async function smtpSend(cfg: SmtpConfig, msg: SmtpMessage): Promise<void> {
+  if (!msg.recipients.length) throw new SmtpError(0, "smtp_no_recipients");
+  const s = await connectAndAuth(cfg);
+  try {
+    await s.send(`MAIL FROM:<${msg.from}>`);
+    await s.expect(250, "mail_from");
+    for (const rcpt of msg.recipients) {
+      await s.send(`RCPT TO:<${rcpt}>`);
+      await s.expect(250, "rcpt_to");
+    }
+    await s.send("DATA");
+    await s.expect(354, "data");
+    await s.writeRaw(dotStuff(msg.raw) + "\r\n.\r\n");
+    await s.expect(250, "message");
+    await s.send("QUIT");
+  } finally {
+    await s.close();
+  }
+}
+
+/** Connect, upgrade and log in, then hang up — what the "Test connection" button runs. */
+export async function smtpVerify(cfg: SmtpConfig): Promise<void> {
+  const s = await connectAndAuth(cfg);
+  try {
+    await s.send("QUIT");
+  } finally {
+    await s.close();
+  }
+}

--- a/src/worker/smtp.ts
+++ b/src/worker/smtp.ts
@@ -32,9 +32,12 @@ export interface SmtpMessage {
 
 export class SmtpError extends Error {
   code: number;
-  constructor(code: number, message: string) {
+  /** True when the server rejected the credentials, which retrying cannot fix. */
+  auth: boolean;
+  constructor(code: number, message: string, opts: { auth?: boolean } = {}) {
     super(message);
     this.code = code;
+    this.auth = opts.auth ?? false;
   }
 }
 
@@ -157,7 +160,13 @@ async function connectAndAuth(cfg: SmtpConfig): Promise<Session> {
       await expect(334, "auth_user");
       await send(b64(cfg.password));
     }
-    await expect(235, "auth");
+    try {
+      await expect(235, "auth");
+    } catch (e) {
+      // 535 and friends mean the credentials are wrong; polling again will not help.
+      if (e instanceof SmtpError && e.code >= 500) throw new SmtpError(e.code, e.message, { auth: true });
+      throw e;
+    }
   } catch (e) {
     await close();
     throw e;

--- a/src/worker/sync.ts
+++ b/src/worker/sync.ts
@@ -2,6 +2,7 @@ import type { Env } from "./env";
 import type { AccountRow, ContactRow, ThreadRow } from "./db";
 import { uid, now, chunk, placeholders, safeJson, runBatch, logSync } from "./db";
 import { gmailJson, gmailBatchGet, GmailError, hasMailScope } from "./google";
+import { MicrosoftError, hasMsMailScope } from "./microsoft";
 import { parseGmailMessage, stripSubjectPrefixes, parseAddressList, type GmailMessage, type ParsedMessage } from "./mime";
 import { stripTrackers, htmlToText } from "./sanitize";
 import { syncContactPhotos } from "./people";
@@ -701,15 +702,23 @@ export async function syncAccount(env: Env, account: AccountRow): Promise<{ adde
   // An account connected for calendar only has no mail scope: every Gmail call would 403. Leave it
   // alone rather than writing a sync error every minute. (An empty `scopes` predates the column and
   // does have mail — see hasMailScope.)
-  if (!hasMailScope(account.scopes)) return { added: 0, status: "no_mail_scope" };
+  if (account.provider === "outlook") {
+    if (!hasMsMailScope(account.scopes)) return { added: 0, status: "no_mail_scope" };
+  } else if (!hasMailScope(account.scopes)) {
+    return { added: 0, status: "no_mail_scope" };
+  }
   // The 'syncing' marker exists so a long run isn't started twice by overlapping cron ticks, and so
   // the UI can show a spinner. An incremental poll finishes in well under a second and needs
-  // neither, so only the initial backfill pays for the marker.
+  // neither, so only the initial backfill pays for the marker. An Outlook mailbox is still walking
+  // its delta chain while `initial_sync_done` is 0, so it pays for the marker on the same terms.
   const slow = !account.initial_sync_done;
   if (slow) await db.prepare(`UPDATE accounts SET sync_status = 'syncing' WHERE id = ?`).bind(account.id).run();
   let added = 0;
   try {
-    if (!account.initial_sync_done) {
+    if (account.provider === "outlook") {
+      const { syncOutlookAccount } = await import("./outlook");
+      added += (await syncOutlookAccount(env, account)).added;
+    } else if (!account.initial_sync_done) {
       await startFromNow(env, account);
     } else {
       added += (await incrementalSync(env, account)).added;
@@ -743,7 +752,8 @@ export async function syncAccount(env: Env, account: AccountRow): Promise<{ adde
     return { added, status: "ok" };
   } catch (e) {
     const msg = (e as Error).message ?? String(e);
-    const disconnected = e instanceof GmailError && (e.status === 401 || /invalid_grant|no_refresh_token/i.test(e.body));
+    const disconnected =
+      (e instanceof GmailError || e instanceof MicrosoftError) && (e.status === 401 || /invalid_grant|no_refresh_token/i.test(e.body));
     await db
       .prepare(`UPDATE accounts SET sync_status = ?, sync_error = ?, last_synced_at = ? WHERE id = ?`)
       .bind(disconnected ? "disconnected" : "error", msg.slice(0, 1000), now(), account.id)

--- a/src/worker/sync.ts
+++ b/src/worker/sync.ts
@@ -698,11 +698,15 @@ const HEARTBEAT_MS = 10 * 60_000;
 export async function syncAccount(env: Env, account: AccountRow): Promise<{ added: number; status: string }> {
   const db = env.DB;
   if (account.sync_status === "disconnected") return { added: 0, status: "disconnected" };
-  if (!account.refresh_token) return { added: 0, status: "disconnected" };
+  // IMAP mailboxes hold a stored password in `imap_accounts`, not an OAuth refresh token, so the
+  // token check below would wrongly disconnect every one of them.
+  if (account.provider !== "imap" && !account.refresh_token) return { added: 0, status: "disconnected" };
   // An account connected for calendar only has no mail scope: every Gmail call would 403. Leave it
   // alone rather than writing a sync error every minute. (An empty `scopes` predates the column and
   // does have mail — see hasMailScope.)
-  if (account.provider === "outlook") {
+  if (account.provider === "imap") {
+    /* nothing to scope-check: an IMAP mailbox either has working credentials or it does not */
+  } else if (account.provider === "outlook") {
     if (!hasMsMailScope(account.scopes)) return { added: 0, status: "no_mail_scope" };
   } else if (!hasMailScope(account.scopes)) {
     return { added: 0, status: "no_mail_scope" };
@@ -715,7 +719,10 @@ export async function syncAccount(env: Env, account: AccountRow): Promise<{ adde
   if (slow) await db.prepare(`UPDATE accounts SET sync_status = 'syncing' WHERE id = ?`).bind(account.id).run();
   let added = 0;
   try {
-    if (account.provider === "outlook") {
+    if (account.provider === "imap") {
+      const { syncImapAccount } = await import("./imapbox");
+      added += (await syncImapAccount(env, account)).added;
+    } else if (account.provider === "outlook") {
       const { syncOutlookAccount } = await import("./outlook");
       added += (await syncOutlookAccount(env, account)).added;
     } else if (!account.initial_sync_done) {

--- a/src/worker/sync.ts
+++ b/src/worker/sync.ts
@@ -3,6 +3,8 @@ import type { AccountRow, ContactRow, ThreadRow } from "./db";
 import { uid, now, chunk, placeholders, safeJson, runBatch, logSync } from "./db";
 import { gmailJson, gmailBatchGet, GmailError, hasMailScope } from "./google";
 import { MicrosoftError, hasMsMailScope } from "./microsoft";
+import { ImapError } from "./imap";
+import { SmtpError } from "./smtp";
 import { parseGmailMessage, stripSubjectPrefixes, parseAddressList, type GmailMessage, type ParsedMessage } from "./mime";
 import { stripTrackers, htmlToText } from "./sanitize";
 import { syncContactPhotos } from "./people";
@@ -758,15 +760,27 @@ export async function syncAccount(env: Env, account: AccountRow): Promise<{ adde
     }
     return { added, status: "ok" };
   } catch (e) {
-    const msg = (e as Error).message ?? String(e);
+    const msg = ((e as Error).message ?? String(e)).slice(0, 1000);
+    // Credentials the server has rejected are not going to start working on the next tick. Gmail and
+    // Graph signal that with a 401; IMAP and SMTP raise it explicitly, so all four retire the account
+    // rather than being re-selected by the cron a minute later, forever.
     const disconnected =
-      (e instanceof GmailError || e instanceof MicrosoftError) && (e.status === 401 || /invalid_grant|no_refresh_token/i.test(e.body));
-    await db
-      .prepare(`UPDATE accounts SET sync_status = ?, sync_error = ?, last_synced_at = ? WHERE id = ?`)
-      .bind(disconnected ? "disconnected" : "error", msg.slice(0, 1000), now(), account.id)
-      .run();
-    await logSync(db, account.id, "error", `Sync failed: ${msg}`);
-    return { added, status: disconnected ? "disconnected" : "error" };
+      ((e instanceof GmailError || e instanceof MicrosoftError) && (e.status === 401 || /invalid_grant|no_refresh_token/i.test(e.body))) ||
+      ((e instanceof ImapError || e instanceof SmtpError) && e.auth);
+    const status = disconnected ? "disconnected" : "error";
+    // An account that keeps failing the same way has nothing new to record. Writing the row anyway
+    // would cost an UPDATE and a log line every minute for as long as the fault lasts — the same
+    // write amplification the heartbeat above exists to avoid on the success path.
+    if (account.sync_status !== status || account.sync_error !== msg) {
+      account.sync_status = status;
+      account.sync_error = msg;
+      await db
+        .prepare(`UPDATE accounts SET sync_status = ?, sync_error = ?, last_synced_at = ? WHERE id = ?`)
+        .bind(status, msg, now(), account.id)
+        .run();
+      await logSync(db, account.id, "error", `Sync failed: ${msg}`);
+    }
+    return { added, status };
   }
 }
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,63 @@
+import { env } from "cloudflare:test";
+import { ensureMigrations } from "../src/worker/migrations";
+import type { Env } from "../src/worker/env";
+import type { AccountRow } from "../src/worker/db";
+
+export const testEnv = env as unknown as Env;
+
+/** Apply every migration once per worker, exactly as the Worker itself does on first request. */
+export async function migrate(): Promise<void> {
+  await ensureMigrations(testEnv);
+}
+
+/** Wipe the tables a mail test touches, so each test starts from a known-empty mailbox. */
+export async function resetData(): Promise<void> {
+  const db = testEnv.DB;
+  for (const t of ["messages", "threads", "contacts", "attachments", "attachment_blobs", "sync_log", "accounts", "users"]) {
+    await db.prepare(`DELETE FROM ${t}`).run();
+  }
+}
+
+export async function seedUser(id = "u1"): Promise<void> {
+  await testEnv.DB.prepare(`INSERT INTO users (id, email, name, password_hash, created_at) VALUES (?, ?, '', 'x', ?)`)
+    .bind(id, `${id}@test.local`, Date.now())
+    .run();
+}
+
+export async function seedOutlookAccount(overrides: Partial<AccountRow> = {}): Promise<AccountRow> {
+  const id = (overrides.id as string) ?? "acc1";
+  await testEnv.DB.prepare(
+    `INSERT INTO accounts (id, user_id, provider, email, display_name, access_token, refresh_token, token_expires_at,
+       scopes, history_id, delta_link, initial_sync_done, initial_sync_page_token, initial_sync_count,
+       sync_status, sync_error, last_synced_at, signature, cover_art, avatar_url, created_at)
+     VALUES (?, 'u1', 'outlook', ?, 'Me', 'tok', 'rtok', ?, 'Mail.ReadWrite Mail.Send', NULL, ?, ?, NULL, 0, 'idle', NULL, NULL, '', '', '', ?)`
+  )
+    .bind(
+      id,
+      (overrides.email as string) ?? "me@outlook.com",
+      Date.now() + 3600_000,
+      (overrides.delta_link as string | null) ?? null,
+      overrides.initial_sync_done ?? 1,
+      Date.now()
+    )
+    .run();
+  return (await testEnv.DB.prepare(`SELECT * FROM accounts WHERE id = ?`).bind(id).first<AccountRow>())!;
+}
+
+/** A minimal but realistic inbound message, as Graph's `/$value` would return it. */
+export function rawMime(opts: { from?: string; subject?: string; messageId?: string; inReplyTo?: string } = {}): string {
+  const { from = "Someone <someone@example.com>", subject = "Hello there", messageId = "<m1@example.com>", inReplyTo } = opts;
+  return [
+    `From: ${from}`,
+    `To: Me <me@outlook.com>`,
+    `Subject: ${subject}`,
+    `Message-ID: ${messageId}`,
+    ...(inReplyTo ? [`In-Reply-To: ${inReplyTo}`, `References: ${inReplyTo}`] : []),
+    `Date: ${new Date().toUTCString()}`,
+    `MIME-Version: 1.0`,
+    `Content-Type: text/plain; charset="UTF-8"`,
+    ``,
+    `Body of the message.`,
+    ``,
+  ].join("\r\n");
+}

--- a/test/imap.test.ts
+++ b/test/imap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { literalSize, quote, parseSearchUids, parseSelect, parseFetchUid } from "../src/worker/imap";
+import { literalSize, quote, parseSearchUids, parseSelect, parseFetchUid, ImapError } from "../src/worker/imap";
 
 describe("literalSize", () => {
   it("reads a trailing literal marker", () => {
@@ -62,5 +62,15 @@ describe("parseFetchUid", () => {
 
   it("returns null when absent", () => {
     expect(parseFetchUid("* 1 FETCH (BODY[] {10}")).toBeNull();
+  });
+});
+
+describe("ImapError", () => {
+  it("marks credential rejections as permanent so sync can retire the account", () => {
+    expect(new ImapError("imap_login_failed", { auth: true }).auth).toBe(true);
+  });
+
+  it("treats anything else as transient and worth retrying", () => {
+    expect(new ImapError("imap_timeout: greeting").auth).toBe(false);
   });
 });

--- a/test/imap.test.ts
+++ b/test/imap.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { literalSize, quote, parseSearchUids, parseSelect, parseFetchUid } from "../src/worker/imap";
+
+describe("literalSize", () => {
+  it("reads a trailing literal marker", () => {
+    expect(literalSize("* 1 FETCH (UID 5 BODY[] {1234}")).toBe(1234);
+  });
+
+  it("ignores a brace that is not at the end", () => {
+    // Only a trailing {n} introduces a literal; braces elsewhere are ordinary text.
+    expect(literalSize("* OK {not a literal} here")).toBeNull();
+  });
+
+  it("returns null for an ordinary line", () => {
+    expect(literalSize("a001 OK LOGIN completed")).toBeNull();
+  });
+});
+
+describe("quote", () => {
+  it("escapes quotes and backslashes so odd passwords cannot break framing", () => {
+    expect(quote('pa"ss')).toBe('"pa\\"ss"');
+    expect(quote("pa\\ss")).toBe('"pa\\\\ss"');
+  });
+
+  it("wraps a plain value", () => {
+    expect(quote("INBOX")).toBe('"INBOX"');
+  });
+});
+
+describe("parseSearchUids", () => {
+  it("collects uids from an untagged SEARCH line", () => {
+    expect(parseSearchUids(["* SEARCH 3 4 7", "a002 OK"])).toEqual([3, 4, 7]);
+  });
+
+  it("handles an empty result", () => {
+    expect(parseSearchUids(["* SEARCH", "a002 OK"])).toEqual([]);
+    expect(parseSearchUids(["a002 OK"])).toEqual([]);
+  });
+});
+
+describe("parseSelect", () => {
+  it("reads UIDVALIDITY, UIDNEXT and EXISTS", () => {
+    const r = parseSelect([
+      "* 12 EXISTS",
+      "* OK [UIDVALIDITY 1568440178] UIDs valid",
+      "* OK [UIDNEXT 4321] Predicted next UID",
+    ]);
+    expect(r).toEqual({ uidValidity: 1568440178, uidNext: 4321, exists: 12 });
+  });
+
+  it("defaults missing fields to zero rather than NaN", () => {
+    expect(parseSelect(["* OK nothing useful"])).toEqual({ uidValidity: 0, uidNext: 0, exists: 0 });
+  });
+});
+
+describe("parseFetchUid", () => {
+  it("finds the UID wherever the server puts it", () => {
+    expect(parseFetchUid("* 1 FETCH (UID 42 BODY[] {10}")).toBe(42);
+    // Some servers order the data items differently.
+    expect(parseFetchUid("* 1 FETCH (BODY[] {10} UID 42)")).toBe(42);
+  });
+
+  it("returns null when absent", () => {
+    expect(parseFetchUid("* 1 FETCH (BODY[] {10}")).toBeNull();
+  });
+});

--- a/test/imapbox.test.ts
+++ b/test/imapbox.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import { migrate, resetData, seedUser, testEnv, rawMime } from "./helpers";
+import { passwordHint, encryptPassword, loadImapRow, configFor, syncImapAccount } from "../src/worker/imapbox";
+import type { AccountRow } from "../src/worker/db";
+
+vi.mock("../src/worker/imap", async (orig) => {
+  const actual = await orig<typeof import("../src/worker/imap")>();
+  return { ...actual, imapFetchNew: vi.fn(), imapVerify: vi.fn() };
+});
+import { imapFetchNew } from "../src/worker/imap";
+
+const fetchNew = imapFetchNew as unknown as ReturnType<typeof vi.fn>;
+const bytes = (s: string) => new TextEncoder().encode(s);
+
+async function seedImapAccount(over: Partial<Record<string, unknown>> = {}): Promise<AccountRow> {
+  const t = Date.now();
+  await testEnv.DB.prepare(
+    `INSERT INTO accounts (id, user_id, provider, email, display_name, access_token, refresh_token, token_expires_at, scopes,
+       history_id, delta_link, initial_sync_done, initial_sync_page_token, initial_sync_count, sync_status, sync_error,
+       last_synced_at, signature, cover_art, avatar_url, created_at)
+     VALUES ('imap1', 'u1', 'imap', 'me@zoho.test', 'Me', NULL, NULL, NULL, '', NULL, NULL, 0, NULL, 0, 'idle', NULL, NULL, '', '', '', ?)`
+  ).bind(t).run();
+  await testEnv.DB.prepare(
+    `INSERT INTO imap_accounts (account_id, imap_host, imap_port, imap_security, smtp_host, smtp_port, smtp_security,
+       username, password_enc, password_hint, folder, uid_validity, last_uid, updated_at)
+     VALUES ('imap1', 'imap.zoho.com', 993, 'tls', 'smtp.zoho.com', 465, 'tls', 'me@zoho.test', ?, '••••34', 'INBOX', ?, ?, ?)`
+  )
+    .bind(await encryptPassword(testEnv, "app-password-1234"), over.uid_validity ?? 100, over.last_uid ?? 5, t)
+    .run();
+  return (await testEnv.DB.prepare(`SELECT * FROM accounts WHERE id = 'imap1'`).first<AccountRow>())!;
+}
+
+beforeAll(migrate);
+beforeEach(async () => {
+  await resetData();
+  await testEnv.DB.prepare(`DELETE FROM imap_accounts`).run();
+  await seedUser();
+  fetchNew.mockReset();
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("migration 0016", () => {
+  it("creates the credentials table", async () => {
+    const r = await testEnv.DB.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='imap_accounts'`).first();
+    expect(r).toBeTruthy();
+  });
+});
+
+describe("passwordHint", () => {
+  it("reveals only the last couple of characters", () => {
+    expect(passwordHint("app-password-1234")).toMatch(/34$/);
+    expect(passwordHint("app-password-1234")).not.toContain("app-password");
+  });
+
+  it("does not leak length for very short secrets", () => {
+    expect(passwordHint("abc")).toBe("••••");
+  });
+});
+
+describe("credential storage", () => {
+  it("round-trips the password through encryption and never stores it in clear", async () => {
+    await seedImapAccount();
+    const row = await loadImapRow(testEnv, "imap1");
+    expect(row!.password_enc).not.toContain("app-password");
+    const cfg = await configFor(testEnv, "imap1");
+    expect(cfg!.imap.password).toBe("app-password-1234");
+    expect(cfg!.smtp.password).toBe("app-password-1234");
+    expect(cfg!.smtp.port).toBe(465);
+  });
+});
+
+describe("syncImapAccount", () => {
+  it("ingests new mail into the Screener and advances the cursor", async () => {
+    const acc = await seedImapAccount();
+    fetchNew.mockResolvedValue({
+      uidValidity: 100,
+      lastUid: 7,
+      reset: false,
+      messages: [{ uid: 7, raw: bytes(rawMime({ messageId: "<a@example.com>" })) }],
+    });
+
+    const r = await syncImapAccount(testEnv, acc);
+
+    expect(r.added).toBe(1);
+    const thread = await testEnv.DB.prepare(`SELECT bucket FROM threads`).first<{ bucket: string }>();
+    expect(thread!.bucket).toBe("screener");
+    const row = await loadImapRow(testEnv, "imap1");
+    expect(row!.last_uid).toBe(7);
+  });
+
+  it("is idempotent when the server replays a message", async () => {
+    const acc = await seedImapAccount();
+    fetchNew.mockResolvedValue({
+      uidValidity: 100,
+      lastUid: 7,
+      reset: false,
+      messages: [{ uid: 7, raw: bytes(rawMime({ messageId: "<a@example.com>" })) }],
+    });
+    await syncImapAccount(testEnv, acc);
+    const second = await syncImapAccount(testEnv, acc);
+    expect(second.added).toBe(0);
+    const n = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM messages`).first<{ n: number }>();
+    expect(n!.n).toBe(1);
+  });
+
+  it("re-baselines instead of re-importing when UIDVALIDITY changes", async () => {
+    // A renumbered folder invalidates every stored UID; importing it all would flood the Screener.
+    const acc = await seedImapAccount();
+    fetchNew.mockResolvedValue({ uidValidity: 999, lastUid: 42, reset: true, messages: [] });
+
+    const r = await syncImapAccount(testEnv, acc);
+
+    expect(r.added).toBe(0);
+    const row = await loadImapRow(testEnv, "imap1");
+    expect(row!.uid_validity).toBe(999);
+    expect(row!.last_uid).toBe(42);
+    const n = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM messages`).first<{ n: number }>();
+    expect(n!.n).toBe(0);
+  });
+
+  it("leaves the cursor alone when ingest throws", async () => {
+    const acc = await seedImapAccount();
+    fetchNew.mockRejectedValue(new Error("imap_fetch_failed: boom"));
+    await expect(syncImapAccount(testEnv, acc)).rejects.toThrow(/boom/);
+    const row = await loadImapRow(testEnv, "imap1");
+    expect(row!.last_uid).toBe(5);
+  });
+
+  it("does nothing for an account with no stored credentials", async () => {
+    const t = Date.now();
+    await testEnv.DB.prepare(
+      `INSERT INTO accounts (id, user_id, provider, email, display_name, initial_sync_done, initial_sync_count, sync_status, signature, cover_art, created_at)
+       VALUES ('orphan', 'u1', 'imap', 'x@y.z', '', 0, 0, 'idle', '', '', ?)`
+    ).bind(t).run();
+    const acc = (await testEnv.DB.prepare(`SELECT * FROM accounts WHERE id='orphan'`).first<AccountRow>())!;
+    expect(await syncImapAccount(testEnv, acc)).toEqual({ added: 0 });
+  });
+});

--- a/test/imapbox.test.ts
+++ b/test/imapbox.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
 import { migrate, resetData, seedUser, testEnv, rawMime } from "./helpers";
-import { passwordHint, encryptPassword, loadImapRow, configFor, syncImapAccount } from "../src/worker/imapbox";
+import { passwordHint, PASSWORD_PLACEHOLDER, encryptPassword, loadImapRow, configFor, syncImapAccount } from "../src/worker/imapbox";
 import type { AccountRow } from "../src/worker/db";
 
 vi.mock("../src/worker/imap", async (orig) => {
@@ -47,13 +47,17 @@ describe("migration 0016", () => {
 });
 
 describe("passwordHint", () => {
-  it("reveals only the last couple of characters", () => {
-    expect(passwordHint("app-password-1234")).toMatch(/34$/);
-    expect(passwordHint("app-password-1234")).not.toContain("app-password");
+  it("reveals nothing at all about the password", () => {
+    // A mailbox password is a credential to someone else's system; the tail of it is worth more to
+    // an attacker than a recognisable hint is worth to the owner.
+    const hint = passwordHint("app-password-1234");
+    expect(hint).toBe(PASSWORD_PLACEHOLDER);
+    expect(hint).not.toContain("1234");
+    expect(hint).not.toContain("app");
   });
 
-  it("does not leak length for very short secrets", () => {
-    expect(passwordHint("abc")).toBe("••••");
+  it("does not vary with the password, so it leaks no length either", () => {
+    expect(passwordHint("abc")).toBe(passwordHint("a-very-much-longer-password"));
   });
 });
 

--- a/test/imapbox.test.ts
+++ b/test/imapbox.test.ts
@@ -39,7 +39,7 @@ beforeEach(async () => {
 });
 afterEach(() => vi.restoreAllMocks());
 
-describe("migration 0016", () => {
+describe("migration 0017_imap", () => {
   it("creates the credentials table", async () => {
     const r = await testEnv.DB.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='imap_accounts'`).first();
     expect(r).toBeTruthy();

--- a/test/microsoft.test.ts
+++ b/test/microsoft.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { msAuthUrl, hasMsMailScope, microsoftConfigured, getMsAccessToken, MicrosoftError } from "../src/worker/microsoft";
+import type { Env } from "../src/worker/env";
+import type { AccountRow } from "../src/worker/db";
+
+const env = { MS_CLIENT_ID: "cid", MS_CLIENT_SECRET: "csecret" } as Env;
+
+describe("microsoftConfigured", () => {
+  it("needs both halves of the credential", () => {
+    expect(microsoftConfigured(env)).toBe(true);
+    expect(microsoftConfigured({ MS_CLIENT_ID: "cid" } as Env)).toBe(false);
+    expect(microsoftConfigured({} as Env)).toBe(false);
+  });
+});
+
+describe("msAuthUrl", () => {
+  const url = new URL(msAuthUrl(env, "state123", "https://mail.example.com/auth/microsoft/callback"));
+
+  it("uses the /common authority so personal and work accounts both work", () => {
+    expect(url.origin + url.pathname).toBe("https://login.microsoftonline.com/common/oauth2/v2.0/authorize");
+  });
+
+  it("asks for every scope the feature needs", () => {
+    const scopes = (url.searchParams.get("scope") ?? "").split(" ");
+    // offline_access is what yields a refresh token; without it sync dies after an hour.
+    expect(scopes).toEqual(expect.arrayContaining(["Mail.ReadWrite", "Mail.Send", "User.Read", "offline_access", "openid", "email", "profile"]));
+  });
+
+  it("round-trips the redirect URI and state", () => {
+    expect(url.searchParams.get("redirect_uri")).toBe("https://mail.example.com/auth/microsoft/callback");
+    expect(url.searchParams.get("state")).toBe("state123");
+    expect(url.searchParams.get("response_type")).toBe("code");
+  });
+
+  it("passes a login hint only when given one", () => {
+    expect(url.searchParams.get("login_hint")).toBeNull();
+    const hinted = new URL(msAuthUrl(env, "s", "https://x/cb", "me@outlook.com"));
+    expect(hinted.searchParams.get("login_hint")).toBe("me@outlook.com");
+  });
+});
+
+describe("hasMsMailScope", () => {
+  it("accepts Graph's resource-qualified scope strings", () => {
+    // Microsoft echoes scopes back fully qualified, so an exact-token match would fail here.
+    expect(hasMsMailScope("https://graph.microsoft.com/Mail.ReadWrite https://graph.microsoft.com/Mail.Send")).toBe(true);
+    expect(hasMsMailScope("Mail.ReadWrite Mail.Send")).toBe(true);
+  });
+
+  it("treats an unrecorded scope set as having mail", () => {
+    expect(hasMsMailScope("")).toBe(true);
+    expect(hasMsMailScope(null)).toBe(true);
+  });
+
+  it("rejects a scope set without mail access", () => {
+    expect(hasMsMailScope("openid profile User.Read")).toBe(false);
+  });
+});
+
+describe("token refresh", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const updates: unknown[][] = [];
+
+  function outlookAccount(overrides: Partial<AccountRow> = {}): AccountRow {
+    return {
+      id: "acc1", user_id: "u1", provider: "outlook", email: "me@outlook.com", display_name: "",
+      access_token: "old", refresh_token: "r1", token_expires_at: Date.now() - 1000,
+      sync_status: "idle", ...overrides,
+    } as unknown as AccountRow;
+  }
+
+  const dbEnv = {
+    ...env,
+    DB: { prepare: () => ({ bind: (...args: unknown[]) => { updates.push(args); return { run: async () => ({}) }; } }) },
+  } as unknown as Env;
+
+  beforeEach(() => {
+    updates.length = 0;
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("persists the rotated refresh token", async () => {
+    // Microsoft rotates refresh tokens: keeping the old one would disconnect the account within the hour.
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: "new", refresh_token: "r2", expires_in: 3600 }), { status: 200 })
+    );
+    const acc = outlookAccount();
+    const token = await getMsAccessToken(dbEnv, acc);
+    expect(token).toBe("new");
+    expect(acc.refresh_token).toBe("r2");
+    expect(updates[0]).toContain("r2");
+  });
+
+  it("keeps the existing refresh token when the response omits one", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "new", expires_in: 3600 }), { status: 200 }));
+    const acc = outlookAccount();
+    await getMsAccessToken(dbEnv, acc);
+    expect(acc.refresh_token).toBe("r1");
+  });
+
+  it("does not refresh a token that is still valid", async () => {
+    const acc = outlookAccount({ access_token: "fresh", token_expires_at: Date.now() + 3600_000 });
+    expect(await getMsAccessToken(dbEnv, acc)).toBe("fresh");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses to refresh a non-Outlook account", async () => {
+    const acc = outlookAccount({ provider: "gmail" } as Partial<AccountRow>);
+    await expect(getMsAccessToken(dbEnv, acc)).rejects.toBeInstanceOf(MicrosoftError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/microsoft.test.ts
+++ b/test/microsoft.test.ts
@@ -1,20 +1,29 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import { migrate, testEnv } from "./helpers";
 import { msAuthUrl, hasMsMailScope, microsoftConfigured, getMsAccessToken, MicrosoftError } from "../src/worker/microsoft";
 import type { Env } from "../src/worker/env";
 import type { AccountRow } from "../src/worker/db";
 
-const env = { MS_CLIENT_ID: "cid", MS_CLIENT_SECRET: "csecret" } as Env;
+// A Worker secret takes precedence over stored credentials, so these resolve without touching the
+// database; the unconfigured case does read it, hence the migrate() below.
+const env = { ...testEnv, MS_CLIENT_ID: "cid", MS_CLIENT_SECRET: "csecret" } as Env;
+
+beforeAll(migrate);
 
 describe("microsoftConfigured", () => {
-  it("needs both halves of the credential", () => {
-    expect(microsoftConfigured(env)).toBe(true);
-    expect(microsoftConfigured({ MS_CLIENT_ID: "cid" } as Env)).toBe(false);
-    expect(microsoftConfigured({} as Env)).toBe(false);
+  it("needs both halves of the credential", async () => {
+    expect(await microsoftConfigured(env)).toBe(true);
+    // Half a pair falls through to the stored credentials, which are empty here.
+    expect(await microsoftConfigured({ ...testEnv, MS_CLIENT_ID: "cid" } as Env)).toBe(false);
+    expect(await microsoftConfigured(testEnv)).toBe(false);
   });
 });
 
 describe("msAuthUrl", () => {
-  const url = new URL(msAuthUrl(env, "state123", "https://mail.example.com/auth/microsoft/callback"));
+  let url: URL;
+  beforeAll(async () => {
+    url = new URL(await msAuthUrl(env, "state123", "https://mail.example.com/auth/microsoft/callback"));
+  });
 
   it("uses the /common authority so personal and work accounts both work", () => {
     expect(url.origin + url.pathname).toBe("https://login.microsoftonline.com/common/oauth2/v2.0/authorize");
@@ -32,9 +41,9 @@ describe("msAuthUrl", () => {
     expect(url.searchParams.get("response_type")).toBe("code");
   });
 
-  it("passes a login hint only when given one", () => {
+  it("passes a login hint only when given one", async () => {
     expect(url.searchParams.get("login_hint")).toBeNull();
-    const hinted = new URL(msAuthUrl(env, "s", "https://x/cb", "me@outlook.com"));
+    const hinted = new URL(await msAuthUrl(env, "s", "https://x/cb", "me@outlook.com"));
     expect(hinted.searchParams.get("login_hint")).toBe("me@outlook.com");
   });
 });
@@ -68,9 +77,16 @@ describe("token refresh", () => {
     } as unknown as AccountRow;
   }
 
+  // Real DB for the credential lookup, but capture the account UPDATE so we can assert on it.
+  const realPrepare = testEnv.DB.prepare.bind(testEnv.DB);
   const dbEnv = {
     ...env,
-    DB: { prepare: () => ({ bind: (...args: unknown[]) => { updates.push(args); return { run: async () => ({}) }; } }) },
+    DB: {
+      prepare: (sql: string) => {
+        if (!sql.includes("UPDATE accounts")) return realPrepare(sql);
+        return { bind: (...args: unknown[]) => { updates.push(args); return { run: async () => ({}) }; } };
+      },
+    },
   } as unknown as Env;
 
   beforeEach(() => {

--- a/test/mime.test.ts
+++ b/test/mime.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { buildRfc822, buildRawMime, buildMimeBase64 } from "../src/worker/mime";
+
+const base = {
+  from: { email: "me@example.com", name: "Me" },
+  to: [{ email: "you@example.com", name: "You" }],
+  subject: "Hello",
+  html: "<p>Hi</p>",
+  text: "Hi",
+};
+
+describe("buildRfc822", () => {
+  it("uses CRLF line endings throughout", () => {
+    const raw = buildRfc822(base);
+    expect(raw).toContain("\r\n");
+    // A bare LF would break strict SMTP servers and some MIME parsers.
+    expect(raw.replace(/\r\n/g, "")).not.toContain("\n");
+  });
+
+  it("is multipart/alternative with no attachments and multipart/mixed with them", () => {
+    expect(buildRfc822(base)).toContain("Content-Type: multipart/alternative");
+    const withAtt = buildRfc822({
+      ...base,
+      attachments: [{ filename: "a.txt", mime_type: "text/plain", data_base64: "aGk=" }],
+    });
+    expect(withAtt).toContain("Content-Type: multipart/mixed");
+    expect(withAtt).toContain('filename="a.txt"');
+  });
+
+  it("carries threading headers only when threading", () => {
+    expect(buildRfc822(base)).not.toContain("In-Reply-To:");
+    const reply = buildRfc822({ ...base, inReplyTo: "<a@x>", references: "<a@x> <b@x>" });
+    expect(reply).toContain("In-Reply-To: <a@x>");
+    expect(reply).toContain("References: <a@x> <b@x>");
+  });
+
+  it("RFC 2047-encodes non-ASCII subjects and display names", () => {
+    const raw = buildRfc822({ ...base, subject: "Résumé", from: { email: "me@example.com", name: "Zoë" } });
+    expect(raw).toContain("=?UTF-8?B?");
+    expect(raw).not.toContain("Subject: Résumé");
+  });
+
+  it("honours a caller-supplied Message-ID so the sender can record what it sent", () => {
+    expect(buildRfc822({ ...base, messageId: "<fixed@example.com>" })).toContain("Message-ID: <fixed@example.com>");
+  });
+
+  it("omits Bcc from headers when asked (envelope-only, for a direct SMTP transport)", () => {
+    const p = { ...base, bcc: [{ email: "secret@example.com", name: "" }] };
+    expect(buildRfc822(p)).toContain("Bcc: secret@example.com");
+    expect(buildRfc822(p, { includeBcc: false })).not.toContain("Bcc:");
+  });
+});
+
+// Every build mints a fresh MIME boundary and Date, so two calls are never byte-identical.
+// These assert the encoding contract instead: what comes back out is the message that went in.
+describe("encoding wrappers", () => {
+  const p = { ...base, messageId: "<fixed@example.com>" };
+
+  it("buildRawMime stays base64url for Gmail", () => {
+    const enc = buildRawMime(p);
+    // base64url alphabet only: no +, / or = padding, so it is safe in Gmail's JSON `raw` field.
+    expect(enc).toMatch(/^[A-Za-z0-9_-]+$/);
+    const decoded = Buffer.from(enc, "base64url").toString("utf8");
+    expect(decoded).toMatch(/^From: "Me" <me@example\.com>\r\n/);
+    expect(decoded).toContain("Message-ID: <fixed@example.com>");
+    expect(decoded).toContain("Subject: Hello");
+  });
+
+  it("buildMimeBase64 is standard base64 for Graph", () => {
+    const enc = buildMimeBase64(p);
+    const decoded = Buffer.from(enc, "base64").toString("utf8");
+    expect(decoded).toMatch(/^From: "Me" <me@example\.com>\r\n/);
+    expect(decoded).toContain("Message-ID: <fixed@example.com>");
+  });
+
+  it("the two wrappers differ only in alphabet", () => {
+    const url = buildRawMime(p);
+    const std = buildMimeBase64(p);
+    // Same length modulo padding; base64url is the padding-free, +/ -> -_ variant.
+    expect(url.replace(/[-_]/g, "")).toHaveLength(std.replace(/[+/=]/g, "").length);
+  });
+});

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { migrate, testEnv } from "./helpers";
-import { resolveCreds, saveCreds, isConfigured, credentialsStatus, secretHint } from "../src/worker/oauth";
+import { resolveCreds, saveCreds, isConfigured, credentialsStatus, secretHint, configuredProviders } from "../src/worker/oauth";
 import type { Env } from "../src/worker/env";
 
 /** The real test env has no OAuth vars set, so `db` and `none` are its natural states. */
@@ -132,5 +132,28 @@ describe("credentialsStatus", () => {
     const row = await testEnv.DB.prepare(`SELECT secret_enc FROM oauth_credentials WHERE provider='microsoft'`).first<{ secret_enc: string }>();
     expect(row!.secret_enc).not.toContain("super-secret-value");
     expect(row!.secret_enc.length).toBeGreaterThan(20);
+  });
+});
+
+describe("configuredProviders", () => {
+  it("answers for both providers in one query", async () => {
+    // /api/me reports both on every call, including the unauthenticated one the login screen
+    // makes, so asking per provider doubled the reads on the app's most-hit endpoint.
+    const before = await configuredProviders(dbOnly);
+    expect(before).toEqual({ google: false, microsoft: false });
+
+    await saveCreds(dbOnly, "google", { client_id: "g", client_secret: "google-secret-value" });
+    expect(await configuredProviders(dbOnly)).toEqual({ google: true, microsoft: false });
+  });
+
+  it("counts a Worker secret without needing the database", async () => {
+    expect(await configuredProviders(withEnv)).toMatchObject({ microsoft: true });
+  });
+
+  it("agrees with isConfigured", async () => {
+    await saveCreds(dbOnly, "microsoft", { client_id: "m", client_secret: "ms-secret-value" });
+    const batch = await configuredProviders(dbOnly);
+    expect(batch.microsoft).toBe(await isConfigured(dbOnly, "microsoft"));
+    expect(batch.google).toBe(await isConfigured(dbOnly, "google"));
   });
 });

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -62,6 +62,40 @@ describe("resolveCreds precedence", () => {
   });
 });
 
+describe("taking over from a Worker secret", () => {
+  it("keeps using the Worker secret until the takeover is explicit", async () => {
+    await saveCreds(withEnv, "microsoft", { client_id: "db-id", client_secret: "db-secret-value" });
+    expect((await resolveCreds(withEnv, "microsoft")).source).toBe("env");
+  });
+
+  it("uses the stored credentials once overriding", async () => {
+    // Without this, a deployment configured by `wrangler secret put` could never rotate from the UI.
+    await saveCreds(withEnv, "microsoft", { client_id: "db-id", client_secret: "db-secret-value", override_env: true });
+    const r = await resolveCreds(withEnv, "microsoft");
+    expect(r).toMatchObject({ clientId: "db-id", clientSecret: "db-secret-value", source: "db" });
+    const st = await credentialsStatus(withEnv, "microsoft");
+    expect(st.overriding).toBe(true);
+    expect(st.env_available).toBe(true);
+  });
+
+  it("falls back to the Worker secret when the override is turned off", async () => {
+    await saveCreds(withEnv, "microsoft", { client_id: "db-id", client_secret: "db-secret-value", override_env: true });
+    await saveCreds(withEnv, "microsoft", { override_env: false });
+    expect((await resolveCreds(withEnv, "microsoft")).source).toBe("env");
+  });
+
+  it("ignores an override with nothing stored behind it", async () => {
+    await saveCreds(withEnv, "microsoft", { override_env: true });
+    expect((await resolveCreds(withEnv, "microsoft")).source).toBe("env");
+  });
+
+  it("reports env_available false when no Worker secret exists", async () => {
+    const st = await credentialsStatus(dbOnly, "microsoft");
+    expect(st.env_available).toBe(false);
+    expect(st.overriding).toBe(false);
+  });
+});
+
 describe("saveCreds is three-state", () => {
   it("leaves the secret alone when it is omitted", async () => {
     await saveCreds(dbOnly, "microsoft", { client_id: "id-1", client_secret: "secret-value-1" });

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -157,3 +157,23 @@ describe("configuredProviders", () => {
     expect(batch.google).toBe(await isConfigured(dbOnly, "google"));
   });
 });
+
+describe("credentialsStatus reports the stored row separately", () => {
+  it("distinguishes stored credentials from the resolved ones", async () => {
+    // Under a Worker secret the resolved fields are always populated, so anything deciding whether
+    // an override has something behind it has to look at the stored row instead.
+    const st = await credentialsStatus(withEnv, "microsoft");
+    expect(st.source).toBe("env");
+    expect(st.secret_hint).toMatch(/Worker secret/i);
+    expect(st.has_stored_secret).toBe(false);
+    expect(st.stored_client_id).toBe("");
+  });
+
+  it("reports a stored secret once one exists, without revealing it", async () => {
+    await saveCreds(dbOnly, "microsoft", { client_id: "db-id", client_secret: "db-secret-value" });
+    const st = await credentialsStatus(withEnv, "microsoft");
+    expect(st.has_stored_secret).toBe(true);
+    expect(st.stored_client_id).toBe("db-id");
+    expect(JSON.stringify(st)).not.toContain("db-secret-value");
+  });
+});

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { migrate, testEnv } from "./helpers";
+import { resolveCreds, saveCreds, isConfigured, credentialsStatus, secretHint } from "../src/worker/oauth";
+import type { Env } from "../src/worker/env";
+
+/** The real test env has no OAuth vars set, so `db` and `none` are its natural states. */
+const dbOnly = testEnv;
+const withEnv = { ...testEnv, MS_CLIENT_ID: "env-id", MS_CLIENT_SECRET: "env-secret" } as Env;
+
+beforeAll(migrate);
+beforeEach(async () => {
+  await testEnv.DB.prepare(`DELETE FROM oauth_credentials`).run();
+});
+
+describe("secretHint", () => {
+  it("shows only the ends of a real secret", () => {
+    const h = secretHint("OHO8Q~verylongsecretvalue_XYZ");
+    expect(h).toContain("…");
+    expect(h).not.toContain("verylongsecret");
+  });
+
+  it("does not leak the length of a short one", () => {
+    expect(secretHint("abc")).toBe("••••");
+  });
+});
+
+describe("resolveCreds precedence", () => {
+  it("reports none when nothing is configured", async () => {
+    const r = await resolveCreds(dbOnly, "microsoft");
+    expect(r.source).toBe("none");
+    expect(await isConfigured(dbOnly, "microsoft")).toBe(false);
+  });
+
+  it("uses stored credentials when no Worker secret is set", async () => {
+    await saveCreds(dbOnly, "microsoft", { client_id: "db-id", client_secret: "db-secret-value" });
+    const r = await resolveCreds(dbOnly, "microsoft");
+    expect(r).toMatchObject({ clientId: "db-id", clientSecret: "db-secret-value", source: "db" });
+  });
+
+  it("lets a Worker secret win over the stored value", async () => {
+    // The env var lives in Cloudflare's secret store, so it must take precedence and an existing
+    // deploy must never change behaviour because someone typed into the settings form.
+    await saveCreds(dbOnly, "microsoft", { client_id: "db-id", client_secret: "db-secret-value" });
+    const r = await resolveCreds(withEnv, "microsoft");
+    expect(r).toMatchObject({ clientId: "env-id", clientSecret: "env-secret", source: "env" });
+  });
+
+  it("ignores a half-configured env pair", async () => {
+    const halfEnv = { ...testEnv, MS_CLIENT_ID: "env-id" } as Env;
+    await saveCreds(dbOnly, "microsoft", { client_id: "db-id", client_secret: "db-secret-value" });
+    expect((await resolveCreds(halfEnv, "microsoft")).source).toBe("db");
+  });
+
+  it("keeps providers independent", async () => {
+    await saveCreds(dbOnly, "microsoft", { client_id: "ms", client_secret: "ms-secret-value" });
+    expect((await resolveCreds(dbOnly, "google")).source).toBe("none");
+  });
+
+  it("treats a client id with no secret as unconfigured", async () => {
+    await saveCreds(dbOnly, "microsoft", { client_id: "only-id" });
+    expect((await resolveCreds(dbOnly, "microsoft")).source).toBe("none");
+  });
+});
+
+describe("saveCreds is three-state", () => {
+  it("leaves the secret alone when it is omitted", async () => {
+    await saveCreds(dbOnly, "microsoft", { client_id: "id-1", client_secret: "secret-value-1" });
+    await saveCreds(dbOnly, "microsoft", { client_id: "id-2" });
+    const r = await resolveCreds(dbOnly, "microsoft");
+    expect(r.clientId).toBe("id-2");
+    expect(r.clientSecret).toBe("secret-value-1");
+  });
+
+  it("clears the secret when passed null", async () => {
+    await saveCreds(dbOnly, "microsoft", { client_id: "id-1", client_secret: "secret-value-1" });
+    await saveCreds(dbOnly, "microsoft", { client_secret: null });
+    expect((await resolveCreds(dbOnly, "microsoft")).source).toBe("none");
+  });
+});
+
+describe("credentialsStatus", () => {
+  it("never returns the secret itself", async () => {
+    await saveCreds(dbOnly, "microsoft", { client_id: "id", client_secret: "super-secret-value" });
+    const st = await credentialsStatus(dbOnly, "microsoft");
+    expect(JSON.stringify(st)).not.toContain("super-secret-value");
+    expect(st.configured).toBe(true);
+    expect(st.source).toBe("db");
+  });
+
+  it("marks env-managed credentials so the UI can lock the form", async () => {
+    const st = await credentialsStatus(withEnv, "microsoft");
+    expect(st.source).toBe("env");
+    expect(st.secret_hint).toMatch(/Worker secret/i);
+  });
+
+  it("stores the secret encrypted, not in clear", async () => {
+    await saveCreds(dbOnly, "microsoft", { client_id: "id", client_secret: "super-secret-value" });
+    const row = await testEnv.DB.prepare(`SELECT secret_enc FROM oauth_credentials WHERE provider='microsoft'`).first<{ secret_enc: string }>();
+    expect(row!.secret_enc).not.toContain("super-secret-value");
+    expect(row!.secret_enc.length).toBeGreaterThan(20);
+  });
+});

--- a/test/outlook-delta.test.ts
+++ b/test/outlook-delta.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { newMessageIdsFromPage, walkDelta } from "../src/worker/outlook";
+import type { AccountRow } from "../src/worker/db";
+import type { Env } from "../src/worker/env";
+
+/** An Outlook account with a token that is nowhere near expiry, so no refresh is attempted. */
+function account(): AccountRow {
+  return {
+    id: "acc1",
+    user_id: "u1",
+    provider: "outlook",
+    email: "me@outlook.com",
+    display_name: "Me",
+    access_token: "tok",
+    refresh_token: "rtok",
+    token_expires_at: Date.now() + 3600_000,
+    history_id: null,
+    delta_link: null,
+    initial_sync_done: 1,
+    initial_sync_page_token: null,
+    initial_sync_count: 0,
+    sync_status: "idle",
+    sync_error: null,
+    last_synced_at: null,
+    signature: "",
+    cover_art: "",
+    created_at: Date.now(),
+  } as unknown as AccountRow;
+}
+
+const env = {} as Env;
+
+function jsonOnce(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+describe("newMessageIdsFromPage", () => {
+  it("keeps created/updated ids", () => {
+    expect(newMessageIdsFromPage({ value: [{ id: "a" }, { id: "b" }] })).toEqual(["a", "b"]);
+  });
+
+  it("drops @removed tombstones", () => {
+    // Delta tracking is collection-level, so deletes and moves arrive on the same page.
+    expect(newMessageIdsFromPage({ value: [{ id: "a" }, { id: "b", "@removed": { reason: "deleted" } }] })).toEqual(["a"]);
+  });
+
+  it("tolerates an empty or absent value array", () => {
+    expect(newMessageIdsFromPage({})).toEqual([]);
+    expect(newMessageIdsFromPage({ value: [] })).toEqual([]);
+  });
+});
+
+describe("walkDelta", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("follows @odata.nextLink to the end and reports done", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonOnce({ value: [{ id: "a" }], "@odata.nextLink": "https://graph.microsoft.com/page2" }))
+      .mockResolvedValueOnce(jsonOnce({ value: [{ id: "b" }], "@odata.deltaLink": "https://graph.microsoft.com/delta-final" }));
+
+    const r = await walkDelta(env, account(), "mailFolders/inbox/messages/delta", { collect: true });
+    expect(r.ids).toEqual(["a", "b"]);
+    expect(r.cursor).toBe("https://graph.microsoft.com/delta-final");
+    expect(r.done).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("collects nothing when priming, but still reaches the deltaLink", async () => {
+    fetchMock.mockResolvedValueOnce(jsonOnce({ value: [{ id: "a" }, { id: "b" }], "@odata.deltaLink": "https://graph.microsoft.com/d" }));
+    const r = await walkDelta(env, account(), "start", { collect: false });
+    expect(r.ids).toEqual([]);
+    expect(r.cursor).toBe("https://graph.microsoft.com/d");
+    expect(r.done).toBe(true);
+  });
+
+  it("stops at the id cap but still hands back a resumable cursor", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonOnce({ value: [{ id: "a" }, { id: "b" }], "@odata.nextLink": "https://graph.microsoft.com/p2" }))
+      .mockResolvedValueOnce(jsonOnce({ value: [{ id: "c" }], "@odata.deltaLink": "https://graph.microsoft.com/d" }));
+
+    const r = await walkDelta(env, account(), "start", { collect: true, maxIds: 2 });
+    expect(r.ids).toEqual(["a", "b"]);
+    // A nextLink is as replayable as a deltaLink, so the cursor advances and page 2 is not re-read.
+    expect(r.cursor).toBe("https://graph.microsoft.com/p2");
+    expect(r.done).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops after MAX_PAGES on a very long chain, still resumable", async () => {
+    for (let i = 0; i < 12; i++) {
+      fetchMock.mockResolvedValueOnce(jsonOnce({ value: [], "@odata.nextLink": `https://graph.microsoft.com/p${i + 1}` }));
+    }
+    const r = await walkDelta(env, account(), "start", { collect: false });
+    expect(r.done).toBe(false);
+    expect(r.cursor).toBe("https://graph.microsoft.com/p10");
+    expect(fetchMock).toHaveBeenCalledTimes(10);
+  });
+
+  it("de-duplicates ids repeated across pages", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonOnce({ value: [{ id: "a" }], "@odata.nextLink": "https://graph.microsoft.com/p2" }))
+      .mockResolvedValueOnce(jsonOnce({ value: [{ id: "a" }, { id: "b" }], "@odata.deltaLink": "https://graph.microsoft.com/d" }));
+    const r = await walkDelta(env, account(), "start", { collect: true });
+    expect(r.ids).toEqual(["a", "b"]);
+  });
+
+  it("never calls the Gmail API", async () => {
+    fetchMock.mockResolvedValueOnce(jsonOnce({ value: [], "@odata.deltaLink": "https://graph.microsoft.com/d" }));
+    await walkDelta(env, account(), "start", { collect: true });
+    for (const call of fetchMock.mock.calls) {
+      expect(String(call[0])).not.toContain("googleapis.com");
+    }
+  });
+});

--- a/test/outlook-send.test.ts
+++ b/test/outlook-send.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import { sendMail } from "../src/worker/send";
+import { migrate, resetData, seedUser, seedOutlookAccount, testEnv } from "./helpers";
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeAll(migrate);
+beforeEach(async () => {
+  await resetData();
+  await seedUser();
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => vi.unstubAllGlobals());
+
+const params = {
+  to: [{ email: "you@example.com", name: "You" }],
+  subject: "Hi there",
+  body_html: "<p>Hello</p>",
+};
+
+describe("sendMail routes on provider", () => {
+  it("sends an Outlook account through Graph, not Gmail", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("", { status: 202 }));
+    const acc = await seedOutlookAccount();
+
+    await sendMail(testEnv, acc, params);
+
+    // Ingesting the sent copy also resolves BIMI logos over DNS, so pick out the send call itself.
+    const call = fetchMock.mock.calls.find((c) => String(c[0]).endsWith("/sendMail"));
+    expect(call).toBeDefined();
+    const [url, init] = call!;
+    expect(String(url)).toBe("https://graph.microsoft.com/v1.0/me/sendMail");
+    expect((init as RequestInit).method).toBe("POST");
+    // Graph's MIME form: base64 of the whole RFC822 message, declared as text/plain.
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["content-type"]).toBe("text/plain");
+    const decoded = Buffer.from(String((init as RequestInit).body), "base64").toString("utf8");
+    expect(decoded).toContain("Subject: Hi there");
+    expect(decoded).toContain("To: \"You\" <you@example.com>");
+  });
+
+  it("never touches the Gmail API for an Outlook account", async () => {
+    // Guards the fall-through class of bug: every Gmail guard used to read `provider === "domain"`.
+    fetchMock.mockResolvedValueOnce(new Response("", { status: 202 }));
+    await sendMail(testEnv, await seedOutlookAccount(), params);
+    for (const call of fetchMock.mock.calls) {
+      expect(String(call[0])).not.toContain("googleapis.com");
+    }
+  });
+
+  it("records the sent message locally, since Graph returns an empty 202", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("", { status: 202 }));
+    const r = await sendMail(testEnv, await seedOutlookAccount(), params);
+
+    expect(r.message_id).not.toBe("");
+    const row = await testEnv.DB.prepare(`SELECT * FROM messages WHERE id = ?`).bind(r.message_id).first<any>();
+    expect(row).toBeTruthy();
+    expect(row.gmail_labels_json).toContain("SENT");
+    expect(row.subject).toBe("Hi there");
+  });
+
+  it("surfaces a Graph failure instead of reporting success", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ error: { code: "ErrorMimeContentInvalidBase64String" } }), { status: 400 }));
+    await expect(sendMail(testEnv, await seedOutlookAccount(), params)).rejects.toThrow(/outlook_send_failed/);
+    const n = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM messages`).first<{ n: number }>();
+    expect(n!.n).toBe(0);
+  });
+
+  it("puts Bcc in the MIME headers, which is how Graph learns the recipients", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("", { status: 202 }));
+    await sendMail(testEnv, await seedOutlookAccount(), { ...params, bcc: [{ email: "secret@example.com", name: "" }] });
+    const call = fetchMock.mock.calls.find((c) => String(c[0]).endsWith("/sendMail"))!;
+    const decoded = Buffer.from(String((call[1] as RequestInit).body), "base64").toString("utf8");
+    expect(decoded).toContain("Bcc: secret@example.com");
+  });
+});

--- a/test/outlook-sync.test.ts
+++ b/test/outlook-sync.test.ts
@@ -28,7 +28,7 @@ async function reload(id = "acc1"): Promise<AccountRow> {
   return (await testEnv.DB.prepare(`SELECT * FROM accounts WHERE id = ?`).bind(id).first<AccountRow>())!;
 }
 
-describe("migration 0015", () => {
+describe("migration 0016_outlook", () => {
   it("adds the delta_link cursor column", async () => {
     const info = await testEnv.DB.prepare(`PRAGMA table_info(accounts)`).all<{ name: string }>();
     expect(info.results.map((r) => r.name)).toContain("delta_link");

--- a/test/outlook-sync.test.ts
+++ b/test/outlook-sync.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import { syncOutlookAccount } from "../src/worker/outlook";
+import { toAccount } from "../src/worker/db";
+import { migrate, resetData, seedUser, seedOutlookAccount, testEnv, rawMime } from "./helpers";
+import type { AccountRow } from "../src/worker/db";
+
+function json(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+}
+function text(body: string) {
+  return new Response(body, { status: 200, headers: { "content-type": "text/plain" } });
+}
+
+const DELTA = "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=NEXT";
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeAll(migrate);
+beforeEach(async () => {
+  await resetData();
+  await seedUser();
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => vi.unstubAllGlobals());
+
+async function reload(id = "acc1"): Promise<AccountRow> {
+  return (await testEnv.DB.prepare(`SELECT * FROM accounts WHERE id = ?`).bind(id).first<AccountRow>())!;
+}
+
+describe("migration 0015", () => {
+  it("adds the delta_link cursor column", async () => {
+    const info = await testEnv.DB.prepare(`PRAGMA table_info(accounts)`).all<{ name: string }>();
+    expect(info.results.map((r) => r.name)).toContain("delta_link");
+  });
+});
+
+describe("first connect", () => {
+  it("records a cursor without importing anything", async () => {
+    // The HEY behaviour: connecting a mailbox imports no history, it only starts watching.
+    fetchMock.mockResolvedValueOnce(json({ value: [{ id: "old1" }, { id: "old2" }], "@odata.deltaLink": DELTA }));
+    const acc = await seedOutlookAccount({ delta_link: null, initial_sync_done: 0 } as never);
+
+    const r = await syncOutlookAccount(testEnv, acc);
+
+    expect(r.added).toBe(0);
+    const after = await reload();
+    expect(after.delta_link).toBe(DELTA);
+    expect(after.initial_sync_done).toBe(1);
+    const msgs = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM messages`).first<{ n: number }>();
+    expect(msgs!.n).toBe(0);
+    // Only the delta walk happened — no message bodies were fetched.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps priming across ticks until it reaches the end of a long chain", async () => {
+    // A big inbox needs more than one invocation to walk; it must not start ingesting halfway.
+    const pages = Array.from({ length: 10 }, (_, i) =>
+      json({ value: [{ id: `old${i}` }], "@odata.nextLink": `https://graph.microsoft.com/p${i + 1}` })
+    );
+    for (const p of pages) fetchMock.mockResolvedValueOnce(p);
+    const acc = await seedOutlookAccount({ delta_link: null, initial_sync_done: 0 } as never);
+
+    await syncOutlookAccount(testEnv, acc);
+
+    const after = await reload();
+    expect(after.initial_sync_done).toBe(0);
+    expect(after.delta_link).toBe("https://graph.microsoft.com/p10");
+    const msgs = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM messages`).first<{ n: number }>();
+    expect(msgs!.n).toBe(0);
+  });
+});
+
+describe("incremental sync", () => {
+  it("ingests new mail into the Screener and advances the cursor", async () => {
+    fetchMock
+      .mockResolvedValueOnce(json({ value: [{ id: "m1" }], "@odata.deltaLink": DELTA }))
+      .mockResolvedValueOnce(text(rawMime()));
+    const acc = await seedOutlookAccount({ delta_link: "https://graph.microsoft.com/old-cursor" });
+
+    const r = await syncOutlookAccount(testEnv, acc);
+
+    expect(r.added).toBe(1);
+    const thread = await testEnv.DB.prepare(`SELECT * FROM threads`).first<{ bucket: string; subject: string }>();
+    // An unknown sender must wait for a yes/no rather than landing in the Imbox.
+    expect(thread!.bucket).toBe("screener");
+    expect(thread!.subject).toBe("Hello there");
+    expect((await reload()).delta_link).toBe(DELTA);
+  });
+
+  it("is idempotent: the same message twice adds one row", async () => {
+    const acc = await seedOutlookAccount({ delta_link: "https://graph.microsoft.com/c0" });
+    fetchMock
+      .mockResolvedValueOnce(json({ value: [{ id: "m1" }], "@odata.deltaLink": DELTA }))
+      .mockResolvedValueOnce(text(rawMime()));
+    await syncOutlookAccount(testEnv, acc);
+
+    fetchMock
+      .mockResolvedValueOnce(json({ value: [{ id: "m1" }], "@odata.deltaLink": DELTA }))
+      .mockResolvedValueOnce(text(rawMime()));
+    const second = await syncOutlookAccount(testEnv, await reload());
+
+    expect(second.added).toBe(0);
+    const n = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM messages`).first<{ n: number }>();
+    expect(n!.n).toBe(1);
+  });
+
+  it("threads a reply onto the original rather than starting a new thread", async () => {
+    const acc = await seedOutlookAccount({ delta_link: "https://graph.microsoft.com/c0" });
+    fetchMock
+      .mockResolvedValueOnce(json({ value: [{ id: "m1" }], "@odata.deltaLink": DELTA }))
+      .mockResolvedValueOnce(text(rawMime({ messageId: "<first@example.com>" })));
+    await syncOutlookAccount(testEnv, acc);
+
+    fetchMock
+      .mockResolvedValueOnce(json({ value: [{ id: "m2" }], "@odata.deltaLink": DELTA }))
+      .mockResolvedValueOnce(text(rawMime({ messageId: "<second@example.com>", subject: "Re: Hello there", inReplyTo: "<first@example.com>" })));
+    await syncOutlookAccount(testEnv, await reload());
+
+    const threads = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM threads`).first<{ n: number }>();
+    expect(threads!.n).toBe(1);
+    const msgs = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM messages`).first<{ n: number }>();
+    expect(msgs!.n).toBe(2);
+  });
+
+  it("leaves the cursor alone when a body fetch fails mid-run", async () => {
+    // Replaying is safe (ingest is idempotent); losing mail is not. The cursor must not move.
+    const before = "https://graph.microsoft.com/c0";
+    const acc = await seedOutlookAccount({ delta_link: before });
+    fetchMock
+      .mockResolvedValueOnce(json({ value: [{ id: "m1" }], "@odata.deltaLink": DELTA }))
+      .mockResolvedValueOnce(new Response("boom", { status: 500 }));
+
+    await expect(syncOutlookAccount(testEnv, acc)).rejects.toThrow();
+    expect((await reload()).delta_link).toBe(before);
+  });
+
+  it("resets to priming when Graph rejects an expired delta token", async () => {
+    // Re-walking as new would dump the whole mailbox into the Screener, so it re-primes instead.
+    const acc = await seedOutlookAccount({ delta_link: "https://graph.microsoft.com/stale" });
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ error: { code: "resyncRequired" } }), { status: 410 }));
+
+    const r = await syncOutlookAccount(testEnv, acc);
+
+    expect(r.added).toBe(0);
+    const after = await reload();
+    expect(after.delta_link).toBeNull();
+    expect(after.initial_sync_done).toBe(0);
+    const n = await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM messages`).first<{ n: number }>();
+    expect(n!.n).toBe(0);
+  });
+
+  it("also resets on syncStateNotFound", async () => {
+    const acc = await seedOutlookAccount({ delta_link: "https://graph.microsoft.com/stale" });
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ error: { code: "syncStateNotFound" } }), { status: 400 }));
+    await syncOutlookAccount(testEnv, acc);
+    expect((await reload()).initial_sync_done).toBe(0);
+  });
+
+  it("stores a mid-chain nextLink so a capped run resumes instead of losing mail", async () => {
+    // Regression: a page carrying more ids than the per-run cap used to drop the surplus.
+    const many = Array.from({ length: 30 }, (_, i) => ({ id: `m${i}` }));
+    // Route by URL: ingest also does BIMI logo lookups, so a fixed queue would run dry.
+    let n = 0;
+    fetchMock.mockImplementation(async (u: unknown) => {
+      const url = String(u);
+      if (url.includes("/$value")) return text(rawMime({ messageId: `<m${n++}@example.com>` }));
+      if (url.startsWith("https://graph.microsoft.com/")) return json({ value: many, "@odata.nextLink": "https://graph.microsoft.com/page2" });
+      // Anything else is an ingest-time side call (BIMI logo lookup).
+      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    });
+    const acc = await seedOutlookAccount({ delta_link: "https://graph.microsoft.com/c0" });
+
+    const r = await syncOutlookAccount(testEnv, acc);
+
+    // Everything on the page it actually read was ingested — nothing silently dropped.
+    expect(r.added).toBe(30);
+    // And the cursor advanced to the nextLink, so page 2 is picked up on the following tick.
+    expect((await reload()).delta_link).toBe("https://graph.microsoft.com/page2");
+  });
+
+  it("never calls the Gmail API", async () => {
+    fetchMock
+      .mockResolvedValueOnce(json({ value: [{ id: "m1" }], "@odata.deltaLink": DELTA }))
+      .mockResolvedValueOnce(text(rawMime()));
+    await syncOutlookAccount(testEnv, await seedOutlookAccount({ delta_link: "https://graph.microsoft.com/c0" }));
+    for (const call of fetchMock.mock.calls) {
+      expect(String(call[0])).not.toContain("googleapis.com");
+    }
+  });
+});
+
+describe("toAccount", () => {
+  it("reports outlook as outlook and never leaks tokens", async () => {
+    const acc = await seedOutlookAccount();
+    const dto = toAccount(acc) as unknown as Record<string, unknown>;
+    // Before 0015 this coerced anything non-domain to "gmail".
+    expect(dto.provider).toBe("outlook");
+    expect(dto).not.toHaveProperty("access_token");
+    expect(dto).not.toHaveProperty("refresh_token");
+  });
+});
+
+describe("cron selection", () => {
+  const SQL = `SELECT id FROM accounts WHERE provider = 'outlook' AND sync_status <> 'disconnected' AND refresh_token IS NOT NULL AND (scopes IS NULL OR scopes = '' OR scopes LIKE '%Mail.ReadWrite%')`;
+
+  it("picks up a healthy Outlook account", async () => {
+    await seedOutlookAccount();
+    const r = await testEnv.DB.prepare(SQL).all<{ id: string }>();
+    expect(r.results.map((x) => x.id)).toEqual(["acc1"]);
+  });
+
+  it("skips a disconnected one", async () => {
+    await seedOutlookAccount();
+    await testEnv.DB.prepare(`UPDATE accounts SET sync_status = 'disconnected' WHERE id = 'acc1'`).run();
+    const r = await testEnv.DB.prepare(SQL).all<{ id: string }>();
+    expect(r.results).toHaveLength(0);
+  });
+
+  it("skips one with no mail scope", async () => {
+    await seedOutlookAccount();
+    await testEnv.DB.prepare(`UPDATE accounts SET scopes = 'openid profile' WHERE id = 'acc1'`).run();
+    const r = await testEnv.DB.prepare(SQL).all<{ id: string }>();
+    expect(r.results).toHaveLength(0);
+  });
+});

--- a/test/smtp.test.ts
+++ b/test/smtp.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { dotStuff, chooseAuth, SmtpError, smtpSend } from "../src/worker/smtp";
+
+describe("dotStuff", () => {
+  it("escapes a leading dot on a continuation line", () => {
+    // Without this the server treats the line as end-of-message and truncates the mail.
+    expect(dotStuff("Hello\r\n.hidden\r\nBye")).toBe("Hello\r\n..hidden\r\nBye");
+  });
+
+  it("escapes a dot at the very start of the message", () => {
+    expect(dotStuff(".leading")).toBe("..leading");
+  });
+
+  it("leaves dots that are not line-initial alone", () => {
+    expect(dotStuff("a.b\r\nc.d")).toBe("a.b\r\nc.d");
+  });
+
+  it("escapes the terminator sequence itself", () => {
+    expect(dotStuff("body\r\n.\r\n")).toBe("body\r\n..\r\n");
+  });
+});
+
+describe("chooseAuth", () => {
+  it("prefers PLAIN when both are offered", () => {
+    expect(chooseAuth("250-mx\r\n250-AUTH LOGIN PLAIN\r\n250 SIZE 1")).toBe("PLAIN");
+  });
+
+  it("falls back to LOGIN", () => {
+    expect(chooseAuth("250-mx\r\n250-AUTH LOGIN\r\n250 SIZE 1")).toBe("LOGIN");
+  });
+
+  it("handles the AUTH= form some servers emit", () => {
+    expect(chooseAuth("250-AUTH=LOGIN PLAIN\r\n250 OK")).toBe("PLAIN");
+  });
+
+  it("returns null when no usable mechanism is advertised", () => {
+    expect(chooseAuth("250-AUTH GSSAPI NTLM\r\n250 OK")).toBeNull();
+    expect(chooseAuth("250-mx\r\n250 SIZE 1")).toBeNull();
+  });
+});
+
+describe("smtpSend guards", () => {
+  const cfg = { host: "smtp.example.com", port: 587, security: "starttls" as const, username: "u", password: "p" };
+
+  it("refuses port 25, which Cloudflare blocks outright", async () => {
+    await expect(smtpSend({ ...cfg, port: 25 }, { from: "a@b.c", recipients: ["d@e.f"], raw: "x" })).rejects.toThrow(
+      /smtp_port_25_blocked/
+    );
+  });
+
+  it("refuses a message with no envelope recipients", async () => {
+    await expect(smtpSend(cfg, { from: "a@b.c", recipients: [], raw: "x" })).rejects.toBeInstanceOf(SmtpError);
+  });
+});

--- a/test/smtp.test.ts
+++ b/test/smtp.test.ts
@@ -52,3 +52,20 @@ describe("smtpSend guards", () => {
     await expect(smtpSend(cfg, { from: "a@b.c", recipients: [], raw: "x" })).rejects.toBeInstanceOf(SmtpError);
   });
 });
+
+describe("SmtpError", () => {
+  it("marks credential rejections as permanent", () => {
+    expect(new SmtpError(535, "smtp_auth_failed", { auth: true }).auth).toBe(true);
+  });
+
+  it("defaults to transient", () => {
+    expect(new SmtpError(0, "smtp_timeout: greeting").auth).toBe(false);
+  });
+});
+
+describe("port guards", () => {
+  const cfg = { host: "h", port: 465, security: "tls" as const, username: "u", password: "p" };
+  it("still refuses port 25 with an explanation", async () => {
+    await expect(smtpSend({ ...cfg, port: 25 }, { from: "a@b.c", recipients: ["d@e.f"], raw: "x" })).rejects.toThrow(/port_25/);
+  });
+});

--- a/test/sync-errors.test.ts
+++ b/test/sync-errors.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeAll, beforeEach, vi, afterEach } from "vitest";
+import { migrate, resetData, seedUser, testEnv } from "./helpers";
+import { syncAccount } from "../src/worker/sync";
+import { ImapError } from "../src/worker/imap";
+import type { AccountRow } from "../src/worker/db";
+
+vi.mock("../src/worker/imapbox", () => ({ syncImapAccount: vi.fn() }));
+import { syncImapAccount } from "../src/worker/imapbox";
+const mockSync = syncImapAccount as unknown as ReturnType<typeof vi.fn>;
+
+async function seedImap(): Promise<AccountRow> {
+  await testEnv.DB.prepare(
+    `INSERT INTO accounts (id, user_id, provider, email, display_name, initial_sync_done, initial_sync_count, sync_status, signature, cover_art, created_at)
+     VALUES ('i1', 'u1', 'imap', 'me@example.com', '', 1, 0, 'idle', '', '', ?)`
+  ).bind(Date.now()).run();
+  return (await testEnv.DB.prepare(`SELECT * FROM accounts WHERE id='i1'`).first<AccountRow>())!;
+}
+const reload = async () => (await testEnv.DB.prepare(`SELECT * FROM accounts WHERE id='i1'`).first<AccountRow>())!;
+const logCount = async () =>
+  (await testEnv.DB.prepare(`SELECT COUNT(*) AS n FROM sync_log WHERE account_id='i1'`).first<{ n: number }>())!.n;
+
+beforeAll(migrate);
+beforeEach(async () => {
+  await resetData();
+  await seedUser();
+  mockSync.mockReset();
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("a mailbox with wrong credentials", () => {
+  it("is disconnected rather than retried forever", async () => {
+    // The cron selects `sync_status <> 'disconnected'`. Anything else is picked up again every
+    // minute for as long as the password stays wrong, costing writes each time.
+    mockSync.mockRejectedValue(new ImapError("imap_login_failed: NO [AUTHENTICATIONFAILED]", { auth: true }));
+    const r = await syncAccount(testEnv, await seedImap());
+    expect(r.status).toBe("disconnected");
+    expect((await reload()).sync_status).toBe("disconnected");
+  });
+
+  it("is then skipped by the cron query entirely", async () => {
+    mockSync.mockRejectedValue(new ImapError("imap_login_failed", { auth: true }));
+    await syncAccount(testEnv, await seedImap());
+    const due = await testEnv.DB.prepare(
+      `SELECT id FROM accounts WHERE provider = 'imap' AND sync_status <> 'disconnected'`
+    ).all<{ id: string }>();
+    expect(due.results).toHaveLength(0);
+  });
+});
+
+describe("a mailbox failing transiently", () => {
+  it("stays in error so it keeps being retried", async () => {
+    mockSync.mockRejectedValue(new ImapError("imap_timeout: greeting"));
+    const r = await syncAccount(testEnv, await seedImap());
+    expect(r.status).toBe("error");
+    expect((await reload()).sync_status).toBe("error");
+  });
+
+  it("does not rewrite the row when the same failure repeats", async () => {
+    // This is the write amplification: one UPDATE plus one log row per account per minute.
+    mockSync.mockRejectedValue(new ImapError("imap_timeout: greeting"));
+    const acc = await seedImap();
+    await syncAccount(testEnv, acc);
+    const afterFirst = await reload();
+    const logsAfterFirst = await logCount();
+
+    for (let i = 0; i < 5; i++) await syncAccount(testEnv, await reload());
+
+    expect(await logCount()).toBe(logsAfterFirst);
+    expect((await reload()).last_synced_at).toBe(afterFirst.last_synced_at);
+  });
+
+  it("does record a failure that has changed", async () => {
+    mockSync.mockRejectedValueOnce(new ImapError("imap_timeout: greeting"));
+    const acc = await seedImap();
+    await syncAccount(testEnv, acc);
+    const before = await logCount();
+    mockSync.mockRejectedValueOnce(new ImapError("imap_select_failed: INBOX"));
+    await syncAccount(testEnv, await reload());
+    expect(await logCount()).toBe(before + 1);
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.worker.json",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers", "node"]
+  },
+  "include": ["test", "vitest.config.ts", "src/worker/sql.d.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import path from "node:path";
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+/**
+ * Wrangler bundles migrations/*.sql as Text modules (see the `rules` entry in wrangler.jsonc).
+ * Vite has no such rule, so mirror it here or `migrations.ts` cannot be imported under test.
+ */
+const sqlAsText = {
+  name: "sql-as-text",
+  transform(_code: string, id: string) {
+    if (!id.endsWith(".sql")) return null;
+    return { code: `export default ${JSON.stringify(fs.readFileSync(id, "utf8"))};`, map: null };
+  },
+};
+
+// Tests run inside workerd against a real (in-memory) D1, so migrations, SQL and the ingest
+// pipeline are exercised for real rather than against a hand-written stub.
+export default defineWorkersConfig({
+  plugins: [sqlAsText],
+  resolve: { alias: { "@shared": path.resolve(__dirname, "src/shared") } },
+  test: {
+    include: ["test/**/*.test.ts"],
+    poolOptions: {
+      workers: {
+        singleWorker: true,
+        miniflare: {
+          compatibilityDate: "2025-09-01",
+          compatibilityFlags: ["nodejs_compat"],
+          d1Databases: { DB: "test-db" },
+        },
+      },
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineWorkersConfig({
           compatibilityDate: "2025-09-01",
           compatibilityFlags: ["nodejs_compat"],
           d1Databases: { DB: "test-db" },
+          bindings: { APP_NAME: "heyflare", SESSION_SECRET: "test-session-secret" },
         },
       },
     },


### PR DESCRIPTION
Closes #3.

Adds two new kinds of mailbox alongside Gmail and domain mailboxes, so an address you already own elsewhere can join the unified Imbox.

## What this adds

**Outlook — `provider = "outlook"`, via Microsoft Graph**

Microsoft retired Basic auth for IMAP/POP/SMTP on 16 September 2024 and removed app passwords with it, so OAuth is the only way into an Outlook mailbox now. With a token in hand, Graph is a better fit than IMAP+XOAUTH2: plain HTTPS, and `@odata.deltaLink` is shaped almost exactly like Gmail's `history_id`.

- `microsoft.ts` — OAuth + Graph client mirroring `google.ts`. Persists the rotated refresh token, which Microsoft (unlike Google) issues on every refresh; not doing so disconnects the account within the hour.
- `outlook.ts` — delta sync. Stores whichever link Graph returns, `@odata.nextLink` or `@odata.deltaLink`, since both are replayable — so the cursor advances mid-chain and a capped run never drops the surplus.
- Sending posts base64 MIME to `/me/sendMail`, which files to Sent Items itself.

**Any IMAP/SMTP mailbox — `provider = "imap"`**

Fastmail, Migadu, cPanel webmail, self-hosted — anything with a password. No OAuth app required.

- `smtp.ts` — submission over 465 implicit TLS or 587 STARTTLS, AUTH PLAIN or LOGIN chosen from the EHLO capabilities, dot-stuffed DATA. Refuses port 25 with an explanation, since Cloudflare blocks it outright.
- `imap.ts` — reads bytes rather than text: IMAP literals are counted in octets and bodies are binary, so decoding early corrupts both the framing and the mail. Raw bytes go straight to postal-mime.
- Cursor is `(UIDVALIDITY, last UID)`; a renumbered folder re-baselines rather than re-importing an entire archive into the Screener.
- Sending goes through the provider's own SMTP, so **they** sign DKIM.

**Rotatable OAuth credentials**

Microsoft client secrets expire — 24 months at most — so rotation is recurring maintenance. Credentials now resolve the way `getSessionSecret` already does: a Worker secret wins when set, otherwise a value stored in D1, AES-GCM encrypted with the existing `ai/crypto` helpers and never returned by the API. Settings gains a **Provider credentials** form, and a deployment configured with `wrangler secret put` can explicitly take over management there rather than being locked out of the UI.

Nothing changes for an existing deploy: env vars keep taking precedence.

## Reusing what was already there

Receiving needed almost no new plumbing. `parseInbound` / `deliverInbound` are already provider-agnostic, so Graph's `/$value` and IMAP's `BODY.PEEK[]` both hand raw MIME to the same path Cloudflare Email Routing uses — the Screener, threading, bundles and the AI agent work unchanged. `buildRawMime` was split into `buildRfc822` plus thin base64/base64url wrappers; the Gmail path is byte-identical.

## Bugs found along the way

Several existing Gmail guards test `provider === "domain"` rather than `!== "gmail"`, so a third provider value falls straight through into Gmail code paths carrying the wrong token — `google.ts` refresh and fetch, send dispatch, attachment serving. `toAccount` also coerced any unknown provider to `"gmail"`, and account deletion POSTed *every* refresh token to Google's revoke endpoint. Fixed here as they blocked the feature, but they're independent of it.

`google_configured` / `microsoft_configured` were returned by the API and never read by the frontend, so **Connect Gmail** appeared on a fresh install and answered with raw JSON and a 500. Both buttons are now gated on the provider actually being configured.

## Tests

The repo had no runner, so this adds **vitest + `@cloudflare/vitest-pool-workers`**, running inside workerd against real D1 — migrations, ingest and SQL are exercised for real. Pinned to vitest 3.2 because vitest 4 requires vite 6+ and this project is on vite 5.

**113 tests.** `npm run check`, `npm test` and `npm run build` all clean. Also adds a CI workflow running the three.

The existing `scripts/ai-openai-mock.test.ts` is untouched — it needs a real Node HTTP server, so it stays a standalone script outside `npm test`.

## What is and isn't verified

Being straight about this, since it should shape how closely you look:

- **Outlook is verified end-to-end** against a real Outlook.com mailbox: consent, token exchange, delta sync, `/$value` MIME through postal-mime, and messages landing in the Screener.
- **IMAP/SMTP is now verified end to end**, against `imap.gmail.com:993` and `smtp.gmail.com:465` with an app password. Adding the mailbox ran `verifyBoth` — a real IMAP `LOGIN` and SMTP `AUTH` — before anything was written; `SELECT INBOX` returned a real UIDVALIDITY and baselined without importing history. A message was then **received** (`UID SEARCH` → `UID FETCH BODY.PEEK[]` → postal-mime → ingest, cursor advancing 164681 → 164682) and another **sent** through SMTP and recorded locally with a `SENT` label. Threading and bucketing behaved as they do for every other provider — the incoming message went straight to the Imbox rather than the Screener, because that sender had already been screened in on a different account, which is the user-wide screening decision working across providers.

- **The native handoff is the one thing still reasoned rather than observed.** Connecting Outlook from the Mac/iOS apps routes through the same system-browser handoff as Google rather than the webview, because Conditional Access can refuse an embedded one. It reuses the path Google already uses in production, but I have not built the Tauri app to confirm it.

So both mail providers are proven against real servers in both directions; the native connect flow rests on argument. The apps need no rebuild either way — they carry no provider-specific code, so new mailbox types arrive with a server deploy.

## Changed during review

Two rounds of review found ten things, all fixed here.

The one that mattered: a mailbox whose credentials stop working was retried **every minute forever**. `syncAccount` only accepted `GmailError`/`MicrosoftError` as grounds for disconnecting, and the cron selects `sync_status <> 'disconnected'` — so a typo'd password cost a TLS handshake, an `UPDATE` and a log row per minute indefinitely. Both clients now flag credential rejections as permanent and the account is retired exactly as a Gmail 401 retires one. The error path also stopped rewriting an unchanged failure, so a permanently unreachable host costs one write rather than one a minute — that part helps Gmail too.

Also: an IMAP mailbox could not be edited, only created and deleted, and deleting takes the synced mail with it — so rotating a mail password meant losing your archive, in a PR half of which is about making rotation painless (`PATCH /api/accounts/:id/imap` plus a **Server settings** dialog). The stored-password hint revealed the last two characters. A server omitting UIDVALIDITY silenced a mailbox permanently instead of erroring. The OAuth override check read the *resolved* credentials, so under a Worker secret it passed with nothing stored behind it. `imap_security` was pinned to `tls` while the form let you pick port 143.

Smaller: IMAP joined sync-on-focus; ports are range-checked; the IMAP socket closes when login throws; `/api/me` reads both providers in one query on a path the login screen hits unauthenticated; CI moved off the deprecated Node 20 actions.

## Migrations

Four, all additive, numbered after `0015_calendar_error`: `0016_outlook` (delta cursor), `0017_imap` (credentials + UID cursor), `0018_oauth_credentials`, `0019_oauth_override`.

## Docs

New `docs/MAILBOXES.md` covers all four mailbox types with setup and a troubleshooting section built from real failures — the Azure personal-account tenant trap (`AADSTS16000`, `401 No access`), Value vs Secret ID, Zoho's free plan, `imappro`/`smtppro` hosts for organisation accounts. `UPDATING.md` gains the new data that survives an update; the README links both.



