### PR TITLE
List the provider's own models instead of a hardcoded set

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -729,6 +729,15 @@ export function useBundleMutations() {
 export function useAiSettings() {
   return useQuery({ queryKey: ["ai", "settings"], queryFn: () => api.get<T.AiSettings>("/api/ai/settings"), staleTime: 30_000 });
 }
+export function useAiModels(enabled: boolean, preset: string, baseUrl: string, apiKey: string) {
+  return useQuery({
+    queryKey: ["ai", "models", preset, baseUrl, apiKey ? "k" : ""],
+    queryFn: () => api.post<{ models: string[]; error?: string }>("/api/ai/models", { preset, base_url: baseUrl, api_key: apiKey }),
+    enabled,
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+}
 export function useAiMemory() {
   return useQuery({ queryKey: ["ai", "memory"], queryFn: () => api.get<T.AiMemoryEntry[]>("/api/ai/memory"), staleTime: 15_000 });
 }

--- a/src/web/components/AiSettingsSection.tsx
+++ b/src/web/components/AiSettingsSection.tsx
@@ -1,15 +1,18 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { Check, ExternalLink, Loader2, Pencil, Plus, RefreshCw, Sparkles, Trash2, X } from "lucide-react";
+import { Check, ChevronsUpDown, ExternalLink, Loader2, Pencil, Plus, RefreshCw, Sparkles, Trash2, X } from "lucide-react";
 import { toast } from "sonner";
 import type { AiMemoryKind, AiPreset } from "@shared/types";
-import { useAiMemory, useAiMutations, useAiSettings } from "../api";
+import { useAiMemory, useAiMutations, useAiSettings, useAiModels } from "../api";
 import { Section, Row, Danger } from "../pages/Settings";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Spinner } from "@/components/ui/spinner";
 import { fmtRelative } from "../lib/format";
 import { cn } from "@/lib/utils";
 
@@ -26,16 +29,22 @@ export function AiSection({ compact }: { compact?: boolean }) {
   const [model, setModel] = useState("");
   const [dirty, setDirty] = useState(false);
   const [clearOpen, setClearOpen] = useState(false);
+  const [modelsOpen, setModelsOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [modelQuery, setModelQuery] = useState("");
   useEffect(() => {
     if (!s || dirty) return;
     setPreset(s.preset);
     setBaseUrl(s.preset === "custom" ? s.base_url : "");
     setModel(s.model);
   }, [s, dirty]);
+  const models = useAiModels(modelsOpen, preset, baseUrl, key.trim());
   const inputCls = compact ? "h-11 text-[16px]" : undefined;
   const p = s?.presets.find((x) => x.id === preset) ?? s?.presets[0];
+  const modelOptions = models.data?.models?.length ? models.data.models : (p?.models ?? []);
   const choosePreset = (id: AiPreset["id"]) => {
     const np = s?.presets.find((x) => x.id === id);
+    setModelsOpen(false);
     setPreset(id);
     setModel(np?.default_model ?? "");
     if (id !== "custom") setBaseUrl("");
@@ -67,7 +76,7 @@ export function AiSection({ compact }: { compact?: boolean }) {
             {preset === "custom" && (
               <Field>
                 <FieldLabel htmlFor="ai-base">Base URL</FieldLabel>
-                <Input id="ai-base" value={baseUrl} onChange={(e) => { setBaseUrl(e.target.value); setDirty(true); }} placeholder="http://localhost:11434/v1" className={inputCls} />
+                <Input id="ai-base" value={baseUrl} onChange={(e) => { setBaseUrl(e.target.value); setModelsOpen(false); setDirty(true); }} placeholder="http://localhost:11434/v1" className={inputCls} />
                 <FieldDescription>Any OpenAI-compatible server: Ollama, LM Studio, Groq, Mistral, Together…</FieldDescription>
               </Field>
             )}
@@ -82,9 +91,58 @@ export function AiSection({ compact }: { compact?: boolean }) {
             </Field>
             <Field>
               <FieldLabel htmlFor="ai-model">Model</FieldLabel>
-              <Input id="ai-model" list="ai-models" value={model} onChange={(e) => { setModel(e.target.value); setDirty(true); }} placeholder={p?.default_model} className={inputCls} />
-              <datalist id="ai-models">{(p?.models ?? []).map((x) => <option key={x} value={x} />)}</datalist>
-              <FieldDescription>Type any model id the provider supports.</FieldDescription>
+              <Popover open={pickerOpen} onOpenChange={(o) => { setPickerOpen(o); if (o) setModelsOpen(true); else setModelQuery(""); }}>
+                <PopoverTrigger asChild>
+                  <Button variant="outline" role="combobox" aria-expanded={pickerOpen} className={cn("w-full justify-between font-normal", inputCls)} id="ai-model">
+                    <span className={cn("truncate", !model && "text-muted-foreground")}>{model || p?.default_model || "Select a model"}</span>
+                    <ChevronsUpDown className="size-4 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-(--radix-popover-trigger-width) p-0">
+                  <Command loop>
+                    <CommandInput placeholder="Search models…" value={modelQuery} onValueChange={setModelQuery} />
+                    <CommandList className="max-h-64">
+                      {models.isFetching ? (
+                        <div className="flex items-center justify-center py-6 text-muted-foreground"><Spinner /></div>
+                      ) : (
+                        <>
+                          <CommandEmpty>{modelQuery ? "No matching model." : "No models listed by this endpoint."}</CommandEmpty>
+                          <CommandGroup>
+                            {modelOptions.map((x) => (
+                              <CommandItem key={x} value={x} onSelect={() => { setModel(x); setDirty(true); setPickerOpen(false); }}>
+                                <span className="flex-1 truncate">{x}</span>
+                                <Check className={cn("size-4", model === x ? "opacity-100" : "opacity-0")} />
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </>
+                      )}
+                      {modelQuery.trim() && !modelOptions.some((x) => x === modelQuery.trim()) && (
+                        <>
+                          <CommandSeparator />
+                          <CommandGroup forceMount>
+                            <CommandItem value={`use-${modelQuery}`} forceMount onSelect={() => { setModel(modelQuery.trim()); setDirty(true); setPickerOpen(false); }}>
+                              <Plus />
+                              <span className="truncate">Use “{modelQuery.trim()}”</span>
+                            </CommandItem>
+                          </CommandGroup>
+                        </>
+                      )}
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+              <FieldDescription className="flex items-center gap-1">
+                {models.isFetching ? (
+                  <><Loader2 className="size-3 animate-spin" /> Loading models…</>
+                ) : models.data?.error || (models.data?.models?.length === 0 && modelsOpen) ? (
+                  "Couldn't list models from this endpoint — search and pick “Use …” to set one by hand."
+                ) : models.data?.models?.length ? (
+                  `${modelOptions.length} models · search or enter your own`
+                ) : (
+                  "Pick a model, or search to enter any id the provider supports."
+                )}
+              </FieldDescription>
             </Field>
           </FieldGroup>
           <div className={cn("flex items-center gap-2 mt-4", compact && "flex-col items-stretch")}>

--- a/src/worker/routes/ai.ts
+++ b/src/worker/routes/ai.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import type { AppEnv } from "../env";
 import type { AccountRow, ThreadRow } from "../db";
 import { uid, now, accountForThread } from "../db";
-import { encryptSecret } from "../ai/crypto";
+import { encryptSecret, decryptSecret } from "../ai/crypto";
 import { PRESETS, MOCK_PRESET, presetById, loadAiSettings, loadAiConfig, makeProvider, describeApiError, AiNotConfigured } from "../ai/provider";
 import { listMemory, addMemory, updateMemory, deleteMemory, clearMemory, learnFromMail, type MemoryKind } from "../ai/memory";
 import { runChatTurn, generateReply, summarizeThread, threadToText, type ChatDeps, type ReplyTone, type SseEvent } from "../ai/chat";
@@ -102,6 +102,58 @@ ai.post("/settings/test", async (c) => {
     return c.json({ ok: true, model: d.cfg.model, reply: r.text.trim().slice(0, 40) });
   } catch (e) {
     return c.json({ ok: false, error: describeApiError(e) }, 400);
+  }
+});
+
+ai.post("/models", async (c) => {
+  const user = c.get("user");
+  const b = await c.req.json<{ preset?: string; base_url?: string; api_key?: string }>().catch(() => ({}) as any);
+  const row = await loadAiSettings(c.env, user.id);
+  const preset = presetById(typeof b.preset === "string" ? b.preset : row?.preset ?? "anthropic");
+  const base = preset.id === "custom" ? String(b.base_url ?? "").trim().replace(/\/+$/, "") : preset.base_url;
+  if (!base || !/^https?:\/\//i.test(base)) return c.json({ models: [] });
+  let key = typeof b.api_key === "string" ? b.api_key.trim() : "";
+  if (!key && row?.api_key_enc) {
+    try {
+      key = await decryptSecret(await getSessionSecret(c.env), row.api_key_enc);
+    } catch {
+      key = "";
+    }
+  }
+  const headers: Record<string, string> = { accept: "application/json" };
+  if (preset.kind === "anthropic") {
+    headers["anthropic-version"] = "2023-06-01";
+    if (key && (key.startsWith("sk-ant-oat") || !key.startsWith("sk-ant-"))) {
+      headers.authorization = `Bearer ${key}`;
+      headers["anthropic-beta"] = "oauth-2025-04-20";
+    } else if (key) {
+      headers["x-api-key"] = key;
+    }
+  } else {
+    if (key) headers.authorization = `Bearer ${key}`;
+    if (preset.id === "openrouter") {
+      headers["HTTP-Referer"] = "https://github.com/doable-team/heyflare";
+      headers["X-Title"] = "heyflare";
+    }
+  }
+  const url = preset.kind === "anthropic" ? `${base}/v1/models?limit=100` : `${base}/models`;
+  try {
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(10_000) });
+    if (!res.ok) {
+      const body = await res.text();
+      return c.json({ models: [], error: `HTTP ${res.status} ${body.trim().slice(0, 200)}`.slice(0, 300) });
+    }
+    const json: any = await res.json().catch(() => null);
+    const arr: any[] = Array.isArray(json?.data) ? json.data : Array.isArray(json?.models) ? json.models : [];
+    const seen = new Set<string>();
+    for (const entry of arr) {
+      const id = typeof entry?.id === "string" ? entry.id : typeof entry?.name === "string" ? entry.name : "";
+      if (id && !seen.has(id)) seen.add(id);
+      if (seen.size >= 500) break;
+    }
+    return c.json({ models: [...seen].sort() });
+  } catch (e) {
+    return c.json({ models: [], error: (e as Error)?.message?.slice(0, 200) ?? "request failed" });
   }
 });
 


### PR DESCRIPTION
The model field in Settings → AI offers a fixed list per preset. For the Custom
(OpenAI-compatible) preset that list is `llama3.1 / mistral / qwen2.5`, which is
no help for whatever endpoint you actually pointed it at.

Opening the model picker now asks the endpoint for its own models.

- New `POST /api/ai/models`. Resolves the base URL from the preset, or the custom
  one, and calls `/models` on it (`/v1/models` with `x-api-key` for Anthropic,
  matching `makeClient`'s handling of OAuth tokens).
- The base URL and key currently typed in the form are sent with the request, not
  just the saved ones — the list is most useful before you've saved anything, and
  plenty of endpoints reject `/v1/models` without a key.
- Failures return an empty list and a message at HTTP 200, never an error, so the
  field falls back to the preset list and stays usable. 10s timeout.
- The picker itself is the Command-in-Popover one `Pickers.tsx` already uses, with
  a "Use ..." row so an unlisted model id is still reachable. That row stays
  outside the loading branch, since a slow endpoint can take the full timeout.

Response parsing accepts `data` or `models`, and `id` or `name` per entry, since
OpenAI-compatible servers vary.

Typechecks and builds clean.